### PR TITLE
feat: 支持社区 Release 跨平台自动更新

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 # `include_str!` preserves checkout bytes; keep embedded docs platform-independent.
 crates/codegen/xai-grok-pager/docs/**/*.md text eol=lf
+packaging/macos/*.sh text eol=lf

--- a/.github/workflows/build-macos-arm.yml
+++ b/.github/workflows/build-macos-arm.yml
@@ -1,4 +1,4 @@
-# 在 GitHub 托管的 Apple Silicon runner 上构建未签名的 grok-zh 预览版。
+# 在 GitHub 托管的 Apple Silicon runner 上构建未签名的 grok-zh。
 # 正式 Release 由唯一的发布工作流统一编排；本工作流只上传 Actions Artifact。
 name: Build macOS ARM
 
@@ -15,19 +15,40 @@ on:
         description: 可选的内嵌版本（默认为 CI 构建编号）
         required: false
         type: string
+  workflow_call:
+    inputs:
+      version:
+        description: 正式 Release 使用的严格 SemVer
+        required: true
+        type: string
+      release_build:
+        description: 标记这是统一 Release 工作流调用的正式构建
+        required: true
+        type: boolean
+    outputs:
+      package_name:
+        value: ${{ jobs.build-macos-arm.outputs.package_name }}
+      archive_name:
+        value: ${{ jobs.build-macos-arm.outputs.archive_name }}
+      artifact_name:
+        value: ${{ jobs.build-macos-arm.outputs.artifact_name }}
 
 permissions:
   contents: read
 
 concurrency:
-  group: macos-arm-preview-${{ github.event.pull_request.number || github.ref }}
+  group: macos-arm-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
   build-macos-arm:
-    name: macOS ARM64 预览版
+    name: ${{ inputs.release_build && 'macOS ARM64 Release' || 'macOS ARM64 预览版' }}
     runs-on: macos-15
     timeout-minutes: 180
+    outputs:
+      package_name: ${{ steps.preview.outputs.package_name }}
+      archive_name: ${{ steps.preview.outputs.archive_name }}
+      artifact_name: ${{ steps.preview.outputs.artifact_name }}
     env:
       CARGO_BUILD_JOBS: "3"
       CARGO_CACHE_SCHEMA: macos-arm-v1
@@ -43,7 +64,7 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: 选择预览版本
+      - name: 选择构建版本
         id: preview
         env:
           REQUESTED_VERSION: ${{ inputs.version }}
@@ -79,6 +100,7 @@ jobs:
           {
             echo "package_name=${package_name}"
             echo "archive_name=${archive_name}"
+            echo "artifact_name=${package_name}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
           } >> "${GITHUB_OUTPUT}"
 
       - name: 确认 Apple Silicon runner
@@ -161,7 +183,7 @@ jobs:
           cargo fetch --locked --target "${TARGET}"
           cargo test --frozen -j "${CARGO_BUILD_JOBS}" -p xai-grok-locale
 
-      - name: 构建 macOS ARM64 预览版
+      - name: 构建 macOS ARM64
         run: |
           set -euo pipefail
           cargo build --frozen -j "${CARGO_BUILD_JOBS}" \
@@ -170,7 +192,9 @@ jobs:
             --profile release-dist \
             --features release-dist
 
-      - name: 打包并验证未签名预览版
+      - name: 打包并验证未签名构建
+        env:
+          IS_RELEASE_BUILD: ${{ inputs.release_build || false }}
         run: |
           set -euo pipefail
           dist="${GITHUB_WORKSPACE}/dist"
@@ -190,6 +214,8 @@ jobs:
             "${package}/THIRD-PARTY-NOTICES-xai-grok-tools.md"
           cp third_party/NOTICE "${package}/NOTICE-third-party.txt"
           cp packaging/macos/INSTALL-MACOS.md "${package}/INSTALL-MACOS.md"
+          cp packaging/macos/Install-GrokZh.sh "${package}/Install-GrokZh.sh"
+          chmod 0755 "${package}/Install-GrokZh.sh"
 
           binary_info="$(file "${package}/grok-zh")"
           binary_archs="$(lipo -archs "${package}/grok-zh")"
@@ -207,8 +233,13 @@ jobs:
           cargo_info="$(cargo --version)"
           dotslash_info="$(dotslash --version | head -n 1)"
           protoc_info="$("${PROTOC}" --version | head -n 1)"
+          if [[ "${IS_RELEASE_BUILD}" == "true" ]]; then
+            build_label="GitHub Release"
+          else
+            build_label="CI 预览版"
+          fi
           cat > "${package}/BUILD-INFO.txt" <<EOF
-          Grok Build 简体中文 macOS ARM64 CI 预览版
+          Grok Build 简体中文 macOS ARM64 ${build_label}
           Product: grok-build-zh
           License: Apache-2.0
           Version: ${GROK_VERSION}
@@ -225,8 +256,9 @@ jobs:
           Architectures: ${binary_archs}
           Code signing: unsigned
           Apple notarization: not submitted
-          Executable smoke-tested by CI: true (--version only)
-          Default command: grok-zh
+          Binary version smoke-tested by CI: true
+          Installer and managed links smoke-tested by CI: true
+          Default commands after installation: grok-zh, agent-zh
           EOF
           sed -i '' 's/^          //' "${package}/BUILD-INFO.txt"
 
@@ -234,6 +266,7 @@ jobs:
             grok-zh
             BUILD-INFO.txt
             INSTALL-MACOS.md
+            Install-GrokZh.sh
             LICENSE-grok-build.txt
             NOTICE-third-party.txt
             SOURCE_REV
@@ -253,7 +286,7 @@ jobs:
           )
 
           archive="${dist}/${ARCHIVE_NAME}"
-          COPYFILE_DISABLE=1 tar -C "${package}" -czf "${archive}" .
+          COPYFILE_DISABLE=1 tar --format=ustar -C "${package}" -czf "${archive}" .
           (
             cd "${dist}"
             shasum -a 256 "${ARCHIVE_NAME}" > "${ARCHIVE_NAME}.sha256"
@@ -276,13 +309,37 @@ jobs:
             echo "::error::解包后的 grok-zh 版本冒烟失败：${verify_version_output}"
             exit 1
           fi
+
+          install_home="${RUNNER_TEMP}/grok-zh-install-smoke-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          if [[ -e "${install_home}" ]]; then
+            echo "::error::安装器验证目录已经存在：${install_home}"
+            exit 1
+          fi
+          GROK_HOME="${install_home}" "${verify_root}/Install-GrokZh.sh"
+          bin_dir="${install_home}/bin"
+          first_target="$(readlink "${bin_dir}/grok-zh")"
+          [[ "${first_target}" == ../grok-zh-downloads/grok-zh-*-macos-aarch64.*.installed ]]
+          [[ "$(readlink "${bin_dir}/agent-zh")" == "grok-zh" ]]
+          [[ ! -e "${bin_dir}/grok" && ! -L "${bin_dir}/grok" ]]
+          [[ ! -e "${bin_dir}/agent" && ! -L "${bin_dir}/agent" ]]
+          installed_version="$("${bin_dir}/grok-zh" --version | head -n 1)"
+          [[ "${installed_version}" == "grok-zh ${GROK_VERSION} ("* ]]
+
+          GROK_HOME="${install_home}" "${verify_root}/Install-GrokZh.sh" --with-compat-aliases
+          second_target="$(readlink "${bin_dir}/grok-zh")"
+          [[ "${second_target}" == ../grok-zh-downloads/grok-zh-*-macos-aarch64.*.installed ]]
+          [[ "${second_target}" != "${first_target}" ]]
+          [[ -f "${bin_dir}/${first_target}" ]]
+          [[ -f "${bin_dir}/${second_target}" ]]
+          alias_version="$("${bin_dir}/grok" --version | head -n 1)"
+          [[ "${alias_version}" == "grok-zh ${GROK_VERSION} ("* ]]
           ls -lh "${archive}" "${archive}.sha256"
 
-      - name: 上传 macOS ARM64 预览版
+      - name: 上传 macOS ARM64 构建
         id: preview_artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: ${{ steps.preview.outputs.package_name }}-${{ github.run_id }}-${{ github.run_attempt }}
+          name: ${{ steps.preview.outputs.artifact_name }}
           path: |
             dist/${{ steps.preview.outputs.archive_name }}
             dist/${{ steps.preview.outputs.archive_name }}.sha256
@@ -291,9 +348,18 @@ jobs:
           retention-days: 14
 
       - name: 在摘要中发布制品详情
+        env:
+          IS_RELEASE_BUILD: ${{ inputs.release_build || false }}
         run: |
+          if [[ "${IS_RELEASE_BUILD}" == "true" ]]; then
+            summary_title="macOS ARM64 Release 构建"
+            usage_note="未经过 Apple Developer ID 签名或公证；发布时由统一 Release 工作流校验并设为不可变。"
+          else
+            summary_title="macOS ARM64 预览版"
+            usage_note="未经过 Apple Developer ID 签名或公证，仅用于预览测试。"
+          fi
           cat >> "${GITHUB_STEP_SUMMARY}" <<EOF
-          ## macOS ARM64 预览版
+          ## ${summary_title}
 
           - 版本：\`${GROK_VERSION}\`
           - 制品：[${PACKAGE_NAME}](${{ steps.preview_artifact.outputs.artifact-url }})
@@ -301,8 +367,8 @@ jobs:
           - 目标：\`${TARGET}\`
           - 软件包外层校验：\`${ARCHIVE_NAME}.sha256\`
           - 软件包内层校验：\`SHA256SUMS.txt\`
-          - 已在 Apple Silicon runner 上执行 \`grok-zh --version\`。
-          - 未经过 Apple Developer ID 签名或公证，仅用于预览测试。
+          - 已在 Apple Silicon runner 上执行二次安装、入口链接与 \`grok-zh --version\` 验证。
+          - ${usage_note}
           EOF
 
       - name: 保存 Cargo macOS release 缓存

--- a/.github/workflows/zh-dev-windows-preview.yml
+++ b/.github/workflows/zh-dev-windows-preview.yml
@@ -425,32 +425,22 @@ jobs:
           Copy-Item -LiteralPath $rgSource.FullName -Destination (Join-Path $package 'rg.exe')
 
           Copy-Item -LiteralPath 'LICENSE' -Destination (Join-Path $package 'LICENSE-grok-build.txt')
-          $rgLicenseDir = Join-Path $package 'licenses\ripgrep'
-          New-Item -ItemType Directory -Path $rgLicenseDir -Force | Out-Null
+          $licenseRoot = Join-Path $package 'licenses'
+          $rgLicenseDir = Join-Path $licenseRoot 'ripgrep'
+          $projectNoticeDir = Join-Path $licenseRoot 'project'
+          New-Item -ItemType Directory -Path $rgLicenseDir,$projectNoticeDir -Force | Out-Null
           foreach ($licenseName in @('COPYING', 'LICENSE-MIT', 'UNLICENSE')) {
             $license = Get-ChildItem -LiteralPath $rgExtract -Filter $licenseName -Recurse -File |
               Select-Object -First 1
-            if ($license) {
-              Copy-Item -LiteralPath $license.FullName -Destination $rgLicenseDir
+            if (!$license) {
+              throw "下载的 ripgrep 压缩包缺少许可证文件：$licenseName"
             }
+            Copy-Item -LiteralPath $license.FullName -Destination $rgLicenseDir
           }
-
-          $manifestNames = @(
-            'grok-zh.exe',
-            'agent-zh.cmd',
-            'rg.exe',
-            '一键安装.cmd',
-            '[可选]替换原始启动方式.cmd',
-            'Install-GrokZh.ps1',
-            'INSTALL-WINDOWS.md'
-          )
-          $manifestLines = foreach ($name in $manifestNames) {
-            $path = Join-Path $package $name
-            $hash = (Get-FileHash -LiteralPath $path -Algorithm SHA256).Hash
-            "$hash  $name"
-          }
-          $manifestLines | Set-Content `
-            -LiteralPath (Join-Path $package 'SHA256SUMS.txt') -Encoding utf8
+          Copy-Item -LiteralPath 'THIRD-PARTY-NOTICES' -Destination $projectNoticeDir
+          Copy-Item -LiteralPath 'crates\codegen\xai-grok-tools\THIRD_PARTY_NOTICES.md' `
+            -Destination $projectNoticeDir
+          Copy-Item -LiteralPath 'third_party\NOTICE' -Destination $projectNoticeDir
 
           $signature = (Get-AuthenticodeSignature -LiteralPath $packageExe).Status
           $pe = (& $objdump -f $packageExe | Select-String 'file format').Line.Trim()
@@ -466,6 +456,31 @@ jobs:
           Default commands after installation: grok-zh, agent-zh
           Optional command takeover: grok, agent
           "@.Trim() | Set-Content -LiteralPath (Join-Path $package 'BUILD-INFO.txt') -Encoding utf8
+
+          $manifestNames = @(
+            'grok-zh.exe',
+            'agent-zh.cmd',
+            'rg.exe',
+            '一键安装.cmd',
+            '[可选]替换原始启动方式.cmd',
+            'Install-GrokZh.ps1',
+            'INSTALL-WINDOWS.md',
+            'LICENSE-grok-build.txt',
+            'BUILD-INFO.txt',
+            'licenses/ripgrep/COPYING',
+            'licenses/ripgrep/LICENSE-MIT',
+            'licenses/ripgrep/UNLICENSE',
+            'licenses/project/THIRD-PARTY-NOTICES',
+            'licenses/project/THIRD_PARTY_NOTICES.md',
+            'licenses/project/NOTICE'
+          )
+          $manifestLines = foreach ($name in $manifestNames) {
+            $path = Join-Path $package $name
+            $hash = (Get-FileHash -LiteralPath $path -Algorithm SHA256).Hash
+            "$hash  $name"
+          }
+          $manifestLines | Set-Content `
+            -LiteralPath (Join-Path $package 'SHA256SUMS.txt') -Encoding utf8
 
           $topLevelEntries = @(Get-ChildItem -LiteralPath $dist -Force)
           if ($topLevelEntries.Count -ne 1 -or !$topLevelEntries[0].PSIsContainer) {

--- a/.github/workflows/zh-release-windows.yml
+++ b/.github/workflows/zh-release-windows.yml
@@ -6,19 +6,25 @@ on:
       - "v*"
 
 permissions:
-  contents: write
-  id-token: write
-  attestations: write
+  contents: read
 
 concurrency:
-  group: zh-release-${{ github.ref_name }}
+  group: zh-release-publisher
   cancel-in-progress: false
 
 jobs:
   windows-x64-gnu:
-    name: Windows x64 GNU 发布
+    name: Windows x64 GNU 构建
     runs-on: windows-2022
     timeout-minutes: 180
+    outputs:
+      release_tag: ${{ steps.release_meta.outputs.release_tag }}
+      grok_version: ${{ steps.release_meta.outputs.grok_version }}
+      zip_name: ${{ steps.release_meta.outputs.zip_name }}
+      is_prerelease: ${{ steps.release_meta.outputs.is_prerelease }}
+      include_macos: ${{ steps.release_meta.outputs.include_macos }}
+      windows_artifact_name: ${{ steps.release_meta.outputs.windows_artifact_name }}
+      notes_artifact_name: ${{ steps.release_meta.outputs.notes_artifact_name }}
     env:
       CARGO_BUILD_JOBS: "4"
       CARGO_INCREMENTAL: "0"
@@ -35,6 +41,7 @@ jobs:
           fetch-depth: 0
 
       - name: 验证标签、版本与发布冲突
+        id: release_meta
         shell: pwsh
         run: |
           $ErrorActionPreference = 'Stop'
@@ -44,6 +51,12 @@ jobs:
             throw "Release Tag 必须是严格三段 vA.B.C 或三段预发布格式，且不得含 build metadata：$tag"
           }
           $version = $matches.version
+          if ($version.Length -gt 64) {
+            throw "Release 版本长度不得超过 64 个字符：$version"
+          }
+          [uint64]$major = $matches['major']
+          [uint64]$minor = $matches['minor']
+          [uint64]$patch = $matches['patch']
           $tagBaseVersion = ($version -split '-', 2)[0]
           foreach ($number in @($matches['major'], $matches['minor'], $matches['patch'])) {
             [uint64]$parsedNumber = 0
@@ -103,11 +116,30 @@ jobs:
             throw "Release $tag 已存在；不可变发布不得覆盖。"
           }
           $packageName = "grok-zh-$version-windows-x86_64-gnu"
+          $zipName = "$packageName.zip"
+          $includeMacos = $major -gt 1 -or
+            ($major -eq 1 -and $minor -gt 0) -or
+            ($major -eq 1 -and $minor -eq 0 -and $patch -ge 7)
+          $isPrerelease = $version.Contains('-').ToString().ToLowerInvariant()
+          $windowsArtifactName = "grok-zh-windows-release-$env:GITHUB_RUN_ID-$env:GITHUB_RUN_ATTEMPT"
+          $notesArtifactName = "grok-zh-release-notes-$env:GITHUB_RUN_ID-$env:GITHUB_RUN_ATTEMPT"
           "RELEASE_TAG=$tag" | Out-File $env:GITHUB_ENV -Append -Encoding utf8
           "GROK_VERSION=$version" | Out-File $env:GITHUB_ENV -Append -Encoding utf8
           "PACKAGE_NAME=$packageName" | Out-File $env:GITHUB_ENV -Append -Encoding utf8
-          "IS_PRERELEASE=$($version.Contains('-').ToString().ToLowerInvariant())" |
+          "ZIP_NAME=$zipName" | Out-File $env:GITHUB_ENV -Append -Encoding utf8
+          "IS_PRERELEASE=$isPrerelease" |
             Out-File $env:GITHUB_ENV -Append -Encoding utf8
+          @{
+            release_tag = $tag
+            grok_version = $version
+            zip_name = $zipName
+            is_prerelease = $isPrerelease
+            include_macos = $includeMacos.ToString().ToLowerInvariant()
+            windows_artifact_name = $windowsArtifactName
+            notes_artifact_name = $notesArtifactName
+          }.GetEnumerator() | ForEach-Object {
+            "$($_.Key)=$($_.Value)" | Out-File $env:GITHUB_OUTPUT -Append -Encoding utf8
+          }
 
       - name: 预生成并验证中文更新日志
         shell: pwsh
@@ -125,6 +157,15 @@ jobs:
           "RELEASE_NOTES_PATH=$notes" | Out-File $env:GITHUB_ENV -Append -Encoding utf8
           "## $env:GROK_VERSION 更新日志" | Out-File $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
           Get-Content -LiteralPath $notes | Out-File $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+
+      - name: 上传 Release 更新日志
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ${{ steps.release_meta.outputs.notes_artifact_name }}
+          path: ${{ env.RELEASE_NOTES_PATH }}
+          if-no-files-found: error
+          compression-level: 0
+          retention-days: 7
 
       - name: 配置固定版本的 Rust、MinGW 和 protoc
         shell: pwsh
@@ -303,28 +344,14 @@ jobs:
           foreach ($licenseName in @('COPYING', 'LICENSE-MIT', 'UNLICENSE')) {
             $license = Get-ChildItem $rgExtract -Filter $licenseName -Recurse -File |
               Select-Object -First 1
-            if ($license) {
-              Copy-Item $license.FullName $rgLicenseDir
+            if (!$license) {
+              throw "下载的 ripgrep 压缩包缺少许可证文件：$licenseName"
             }
+            Copy-Item $license.FullName $rgLicenseDir
           }
           Copy-Item 'THIRD-PARTY-NOTICES' $projectNoticeDir
           Copy-Item 'crates\codegen\xai-grok-tools\THIRD_PARTY_NOTICES.md' $projectNoticeDir
           Copy-Item 'third_party\NOTICE' $projectNoticeDir
-
-          $manifestNames = @(
-            'grok-zh.exe',
-            'agent-zh.cmd',
-            'rg.exe',
-            '一键安装.cmd',
-            '[可选]替换原始启动方式.cmd',
-            'Install-GrokZh.ps1',
-            'INSTALL-WINDOWS.md'
-          )
-          $manifest = foreach ($name in $manifestNames) {
-            $hash = (Get-FileHash -LiteralPath (Join-Path $package $name) -Algorithm SHA256).Hash
-            "$hash  $name"
-          }
-          $manifest | Set-Content (Join-Path $package 'SHA256SUMS.txt') -Encoding utf8
 
           $signature = (Get-AuthenticodeSignature $packageExe).Status
           $pe = (& 'C:\mingw64\bin\objdump.exe' -f $packageExe |
@@ -348,6 +375,29 @@ jobs:
           Default commands after installation: grok-zh, agent-zh
           "@.Trim() | Set-Content (Join-Path $package 'BUILD-INFO.txt') -Encoding utf8
 
+          $manifestNames = @(
+            'grok-zh.exe',
+            'agent-zh.cmd',
+            'rg.exe',
+            '一键安装.cmd',
+            '[可选]替换原始启动方式.cmd',
+            'Install-GrokZh.ps1',
+            'INSTALL-WINDOWS.md',
+            'LICENSE-grok-build.txt',
+            'BUILD-INFO.txt',
+            'licenses/ripgrep/COPYING',
+            'licenses/ripgrep/LICENSE-MIT',
+            'licenses/ripgrep/UNLICENSE',
+            'licenses/project/THIRD-PARTY-NOTICES',
+            'licenses/project/THIRD_PARTY_NOTICES.md',
+            'licenses/project/NOTICE'
+          )
+          $manifest = foreach ($name in $manifestNames) {
+            $hash = (Get-FileHash -LiteralPath (Join-Path $package $name) -Algorithm SHA256).Hash
+            "$hash  $name"
+          }
+          $manifest | Set-Content (Join-Path $package 'SHA256SUMS.txt') -Encoding utf8
+
           if (Get-ChildItem $package -Filter '*.zip' -Recurse -File) {
             throw '安装包目录不得包含嵌套 ZIP。'
           }
@@ -370,7 +420,15 @@ jobs:
             '一键安装.cmd',
             '[可选]替换原始启动方式.cmd',
             'Install-GrokZh.ps1',
-            'INSTALL-WINDOWS.md'
+            'INSTALL-WINDOWS.md',
+            'LICENSE-grok-build.txt',
+            'BUILD-INFO.txt',
+            'licenses/ripgrep/COPYING',
+            'licenses/ripgrep/LICENSE-MIT',
+            'licenses/ripgrep/UNLICENSE',
+            'licenses/project/THIRD-PARTY-NOTICES',
+            'licenses/project/THIRD_PARTY_NOTICES.md',
+            'licenses/project/NOTICE'
           )
           $manifestPath = Join-Path $verifyRoot 'SHA256SUMS.txt'
           if (!(Test-Path -LiteralPath $manifestPath -PathType Leaf)) {
@@ -387,15 +445,18 @@ jobs:
           foreach ($rawLine in (Get-Content -LiteralPath $manifestPath -Encoding UTF8)) {
             $lineNumber++
             $line = $rawLine.TrimStart([char]0xFEFF)
-            $match = [regex]::Match($line, '^(?<hash>[0-9A-Fa-f]{64})  (?<name>[^\\/]+)$')
+            $match = [regex]::Match($line, '^(?<hash>[0-9A-Fa-f]{64})  (?<name>[^\\]+)$')
             if (!$match.Success) {
               throw "SHA256SUMS.txt 第 $lineNumber 行格式无效。"
             }
             $name = $match.Groups['name'].Value
             $isAscii = $name -cmatch '^[\x00-\x7F]+$'
+            $pathParts = $name.Split('/')
             if ($name.Trim() -ne $name -or
+                $name.StartsWith('/') -or
                 $name.Contains(':') -or
-                $name -in @('.', '..') -or
+                $pathParts.Count -eq 0 -or
+                ($pathParts | Where-Object { $_ -in @('', '.', '..') }).Count -ne 0 -or
                 $required -cnotcontains $name -or
                 (!$isAscii -and $allowedUnicodeNames -cnotcontains $name)) {
               throw "SHA256SUMS.txt 包含不安全或未批准的文件名：$name"
@@ -423,6 +484,18 @@ jobs:
               throw "Release ZIP 清单缺少必需文件：$name"
             }
           }
+          $expectedFiles = @($required + 'SHA256SUMS.txt')
+          $actualFiles = @(Get-ChildItem -LiteralPath $verifyRoot -Recurse -File | ForEach-Object {
+            [IO.Path]::GetRelativePath($verifyRoot, $_.FullName).Replace(
+              [IO.Path]::DirectorySeparatorChar,
+              '/'
+            )
+          })
+          $missingFiles = @($expectedFiles | Where-Object { $actualFiles -cnotcontains $_ })
+          $extraFiles = @($actualFiles | Where-Object { $expectedFiles -cnotcontains $_ })
+          if ($missingFiles.Count -ne 0 -or $extraFiles.Count -ne 0) {
+            throw "Release ZIP 文件集合不精确；缺少：$($missingFiles -join ', ')；额外：$($extraFiles -join ', ')"
+          }
           $verifyExe = Join-Path $verifyRoot 'grok-zh.exe'
           $versionOutput = (& $verifyExe --version | Select-Object -First 1).Trim()
           if ($LASTEXITCODE -ne 0 -or
@@ -439,14 +512,138 @@ jobs:
           "DIST_DIR=$dist" | Out-File $env:GITHUB_ENV -Append -Encoding utf8
           "ZIP_NAME=$zipName" | Out-File $env:GITHUB_ENV -Append -Encoding utf8
 
-      - name: 为 Release 资产生成构建来源证明
+
+      - name: 上传 Windows Release 资产
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ${{ steps.release_meta.outputs.windows_artifact_name }}
+          path: |
+            dist/${{ steps.release_meta.outputs.zip_name }}
+            dist/${{ steps.release_meta.outputs.zip_name }}.sha256
+          if-no-files-found: error
+          compression-level: 0
+          retention-days: 7
+
+  macos-arm-release:
+    name: macOS ARM64 构建
+    needs: windows-x64-gnu
+    if: ${{ needs.windows-x64-gnu.outputs.include_macos == 'true' }}
+    uses: ./.github/workflows/build-macos-arm.yml
+    with:
+      version: ${{ needs.windows-x64-gnu.outputs.grok_version }}
+      release_build: true
+
+  release-attestations:
+    name: 生成 Release 资产构建来源证明
+    needs:
+      - windows-x64-gnu
+      - macos-arm-release
+    if: >-
+      ${{
+        !cancelled() &&
+        needs.windows-x64-gnu.result == 'success' &&
+        (
+          needs.macos-arm-release.result == 'success' ||
+          (
+            needs.macos-arm-release.result == 'skipped' &&
+            needs.windows-x64-gnu.outputs.include_macos == 'false'
+          )
+        )
+      }}
+    runs-on: windows-2022
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+    env:
+      ZIP_NAME: ${{ needs.windows-x64-gnu.outputs.zip_name }}
+      MAC_ARCHIVE_NAME: ${{ needs.macos-arm-release.outputs.archive_name }}
+    steps:
+      - name: 下载 Windows Release 资产
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ needs.windows-x64-gnu.outputs.windows_artifact_name }}
+          path: dist
+
+      - name: 下载 macOS Release 资产
+        if: ${{ needs.windows-x64-gnu.outputs.include_macos == 'true' }}
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ needs.macos-arm-release.outputs.artifact_name }}
+          path: dist
+
+      - name: 为 Windows Release 资产生成构建来源证明
         uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
         with:
           subject-path: |
             ${{ github.workspace }}/dist/${{ env.ZIP_NAME }}
             ${{ github.workspace }}/dist/${{ env.ZIP_NAME }}.sha256
 
+      - name: 为 macOS Release 资产生成构建来源证明
+        if: ${{ needs.windows-x64-gnu.outputs.include_macos == 'true' }}
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
+        with:
+          subject-path: |
+            ${{ github.workspace }}/dist/${{ env.MAC_ARCHIVE_NAME }}
+            ${{ github.workspace }}/dist/${{ env.MAC_ARCHIVE_NAME }}.sha256
+
+  release-publisher:
+    name: 核验并发布唯一 Release
+    needs:
+      - windows-x64-gnu
+      - macos-arm-release
+      - release-attestations
+    if: >-
+      ${{
+        !cancelled() &&
+        needs.windows-x64-gnu.result == 'success' &&
+        needs.release-attestations.result == 'success' &&
+        (
+          needs.macos-arm-release.result == 'success' ||
+          (
+            needs.macos-arm-release.result == 'skipped' &&
+            needs.windows-x64-gnu.outputs.include_macos == 'false'
+          )
+        )
+      }}
+    runs-on: windows-2022
+    timeout-minutes: 30
+    permissions:
+      contents: write
+      attestations: read
+    env:
+      GH_TOKEN: ${{ github.token }}
+      RELEASE_TAG: ${{ needs.windows-x64-gnu.outputs.release_tag }}
+      GROK_VERSION: ${{ needs.windows-x64-gnu.outputs.grok_version }}
+      ZIP_NAME: ${{ needs.windows-x64-gnu.outputs.zip_name }}
+      MAC_ARCHIVE_NAME: ${{ needs.macos-arm-release.outputs.archive_name }}
+      INCLUDE_MACOS: ${{ needs.windows-x64-gnu.outputs.include_macos }}
+      IS_PRERELEASE: ${{ needs.windows-x64-gnu.outputs.is_prerelease }}
+      DIST_DIR: ${{ github.workspace }}\dist
+      RELEASE_NOTES_PATH: ${{ github.workspace }}\release-notes\release-notes.md
+    steps:
+      - name: 下载 Windows Release 资产
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ needs.windows-x64-gnu.outputs.windows_artifact_name }}
+          path: dist
+
+      - name: 下载 Release 更新日志
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ needs.windows-x64-gnu.outputs.notes_artifact_name }}
+          path: release-notes
+
+      - name: 下载 macOS Release 资产
+        if: ${{ needs.windows-x64-gnu.outputs.include_macos == 'true' }}
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ needs.macos-arm-release.outputs.artifact_name }}
+          path: dist
+
       - name: 创建 Draft、核验资产并发布
+        id: publish
         shell: pwsh
         run: |
           $ErrorActionPreference = 'Stop'
@@ -455,9 +652,65 @@ jobs:
             (Join-Path $dist $env:ZIP_NAME),
             (Join-Path $dist "$env:ZIP_NAME.sha256")
           )
+          if ($env:INCLUDE_MACOS -eq 'true') {
+            $assets += @(
+              (Join-Path $dist $env:MAC_ARCHIVE_NAME),
+              (Join-Path $dist "$env:MAC_ARCHIVE_NAME.sha256")
+            )
+          }
           $notes = $env:RELEASE_NOTES_PATH
           if (!(Test-Path -LiteralPath $notes -PathType Leaf)) {
             throw "缺少预生成的 Release 更新日志：$notes"
+          }
+          foreach ($assetPath in $assets) {
+            if (!(Test-Path -LiteralPath $assetPath -PathType Leaf)) {
+              throw "缺少待发布资产：$assetPath"
+            }
+          }
+          function Assert-ChecksumSidecar([string]$archivePath) {
+            $sidecarPath = "$archivePath.sha256"
+            $archiveName = Split-Path $archivePath -Leaf
+            $sidecarLines = @(Get-Content -LiteralPath $sidecarPath -Encoding UTF8)
+            if ($sidecarLines.Count -ne 1 -or
+                $sidecarLines[0] -cnotmatch '^(?<hash>[0-9a-f]{64})  (?<name>[^\\/]+)$' -or
+                $matches.name -cne $archiveName) {
+              throw "校验文件格式或目标文件名无效：$sidecarPath"
+            }
+            $archiveHash = (Get-FileHash -LiteralPath $archivePath -Algorithm SHA256).Hash.ToLowerInvariant()
+            if ($matches.hash -cne $archiveHash) {
+              throw "校验文件内容与资产 SHA-256 不一致：$sidecarPath"
+            }
+          }
+          Assert-ChecksumSidecar (Join-Path $dist $env:ZIP_NAME)
+          if ($env:INCLUDE_MACOS -eq 'true') {
+            Assert-ChecksumSidecar (Join-Path $dist $env:MAC_ARCHIVE_NAME)
+          }
+          $expectedLocalNames = @($assets | ForEach-Object { Split-Path $_ -Leaf })
+          [Array]::Sort($expectedLocalNames, [StringComparer]::Ordinal)
+          $actualLocalNames = @(
+            Get-ChildItem -LiteralPath $dist -File | ForEach-Object Name
+          )
+          [Array]::Sort($actualLocalNames, [StringComparer]::Ordinal)
+          if (($expectedLocalNames -join "`n") -cne ($actualLocalNames -join "`n")) {
+            throw "发布目录不是精确资产集合：$($actualLocalNames -join ', ')"
+          }
+
+          $releasePages = @(
+            gh api --paginate --slurp "repos/$env:GITHUB_REPOSITORY/releases?per_page=100" |
+              ConvertFrom-Json
+          )
+          if ($LASTEXITCODE -ne 0) {
+            throw "发布前无法读取现有 Release 列表：$LASTEXITCODE"
+          }
+          $existing = @(
+            foreach ($page in $releasePages) {
+              foreach ($candidate in @($page)) {
+                if ($candidate.tag_name -ceq $env:RELEASE_TAG) { $candidate }
+              }
+            }
+          )
+          if ($existing.Count -ne 0) {
+            throw "Release $env:RELEASE_TAG 已存在；不可变发布不得覆盖。"
           }
 
           function Resolve-RemoteTagCommit {
@@ -493,7 +746,6 @@ jobs:
           if ($LASTEXITCODE -ne 0) {
             throw "创建 Draft Release 失败：$LASTEXITCODE"
           }
-
           # GitHub's tag lookup endpoint does not expose draft releases. Enumerate
           # the authenticated release list and require one exact draft instead.
           $releaseMatches = @()
@@ -518,6 +770,7 @@ jobs:
             throw "没有找到唯一的 Draft Release：$env:RELEASE_TAG"
           }
           $releaseId = $releaseMatches[0].id
+          "release_id=$releaseId" | Out-File $env:GITHUB_OUTPUT -Append -Encoding utf8
           $release = $null
           for ($attempt = 0; $attempt -lt 15; $attempt++) {
             $releaseJson = (& gh api "repos/$env:GITHUB_REPOSITORY/releases/$releaseId" 2>$null) -join "`n"
@@ -551,10 +804,7 @@ jobs:
           if ($release.name -cne $env:GROK_VERSION -or $release.body.Trim() -cne $expectedNotes) {
             throw 'Draft Release 的标题或正文与预生成更新日志不一致。'
           }
-          $expectedNames = @(
-            $env:ZIP_NAME,
-            "$env:ZIP_NAME.sha256"
-          )
+          $expectedNames = @($assets | ForEach-Object { Split-Path $_ -Leaf })
           [Array]::Sort($expectedNames, [StringComparer]::Ordinal)
           $actualNames = @($release.assets | ForEach-Object name)
           [Array]::Sort($actualNames, [StringComparer]::Ordinal)
@@ -572,15 +822,51 @@ jobs:
             }
           }
 
-          $editArgs = @('release', 'edit', $env:RELEASE_TAG, '--repo', $env:GITHUB_REPOSITORY, '--draft=false')
-          if ($env:IS_PRERELEASE -eq 'true') {
-            $editArgs += @('--prerelease', '--latest=false')
-          } else {
-            $editArgs += '--latest'
+          # Re-read the exact captured Draft immediately before publication.
+          # Publishing by numeric ID avoids editing a replacement Release that
+          # happens to reuse the same Tag name.
+          $beforePublish = gh api "repos/$env:GITHUB_REPOSITORY/releases/$releaseId" |
+            ConvertFrom-Json
+          if ($LASTEXITCODE -ne 0 -or !$beforePublish.draft -or
+              [int64]$beforePublish.id -ne [int64]$releaseId -or
+              $beforePublish.tag_name -cne $env:RELEASE_TAG -or
+              $beforePublish.name -cne $env:GROK_VERSION -or
+              $beforePublish.body.Trim() -cne $expectedNotes) {
+            throw '发布前 Draft Release 的身份或元数据发生变化。'
           }
-          & gh @editArgs
+          $beforeNames = @($beforePublish.assets | ForEach-Object name)
+          [Array]::Sort($beforeNames, [StringComparer]::Ordinal)
+          if (($expectedNames -join "`n") -cne ($beforeNames -join "`n")) {
+            throw '发布前 Draft Release 的资产集合发生变化。'
+          }
+          foreach ($asset in $beforePublish.assets) {
+            $localHash = (Get-FileHash (Join-Path $dist $asset.name) -Algorithm SHA256).Hash.ToLowerInvariant()
+            if ($asset.state -cne 'uploaded' -or
+                $asset.digest -cnotmatch '^sha256:[0-9a-f]{64}$' -or
+                $asset.digest.Substring('sha256:'.Length) -cne $localHash) {
+              throw "发布前 $($asset.name) 的状态或 digest 发生变化。"
+            }
+          }
+          $remoteTagCommit = Resolve-RemoteTagCommit
+          if ($remoteTagCommit -cne $env:GITHUB_SHA) {
+            throw "发布前远端 Tag 指向发生变化：tag=$remoteTagCommit workflow=$env:GITHUB_SHA"
+          }
+
+          $isPrerelease = $env:IS_PRERELEASE -eq 'true'
+          $publishArgs = @(
+            'api', '--method', 'PATCH',
+            "repos/$env:GITHUB_REPOSITORY/releases/$releaseId",
+            '-F', 'draft=false',
+            '-F', "prerelease=$($isPrerelease.ToString().ToLowerInvariant())",
+            '-f', "make_latest=$(if ($isPrerelease) { 'false' } else { 'true' })"
+          )
+          $publishJson = (& gh @publishArgs) -join "`n"
           if ($LASTEXITCODE -ne 0) {
             throw "发布 Release 失败：$LASTEXITCODE"
+          }
+          $publishResult = $publishJson | ConvertFrom-Json
+          if ([int64]$publishResult.id -ne [int64]$releaseId -or [bool]$publishResult.draft) {
+            throw '发布 API 返回了错误的 Release 身份或仍处于 Draft 状态。'
           }
 
           $published = $null
@@ -599,7 +885,8 @@ jobs:
             }
             Start-Sleep -Seconds 2
           }
-          if ($null -eq $published -or [bool]$published.draft -or ![bool]$published.immutable) {
+          if ($null -eq $published -or [int64]$published.id -ne [int64]$releaseId -or
+              [bool]$published.draft -or ![bool]$published.immutable) {
             throw 'Release 发布后未进入 immutable 状态。'
           }
           if ([bool]$published.prerelease -ne [bool]($env:IS_PRERELEASE -eq 'true')) {
@@ -624,7 +911,81 @@ jobs:
               throw "Release 发布后 $($asset.name) 的 digest 与本地资产不一致。"
             }
           }
+          foreach ($assetPath in $assets) {
+            & gh attestation verify $assetPath `
+              --repo $env:GITHUB_REPOSITORY `
+              --signer-workflow "$env:GITHUB_REPOSITORY/.github/workflows/zh-release-windows.yml" `
+              --source-ref "refs/tags/$env:RELEASE_TAG"
+            if ($LASTEXITCODE -ne 0) {
+              throw "Release 资产的构建来源证明验证失败：$assetPath"
+            }
+          }
           $remoteTagCommit = Resolve-RemoteTagCommit
           if ($remoteTagCommit -cne $env:GITHUB_SHA) {
             throw "Release 发布后远端 Tag 指向发生变化：tag=$remoteTagCommit workflow=$env:GITHUB_SHA"
           }
+
+      - name: 失败时清理本次遗留的 Draft Release
+        if: ${{ failure() || cancelled() }}
+        shell: pwsh
+        env:
+          CREATED_RELEASE_ID: ${{ steps.publish.outputs.release_id }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $release = $null
+          if (![string]::IsNullOrWhiteSpace($env:CREATED_RELEASE_ID)) {
+            $releaseJson = (& gh api "repos/$env:GITHUB_REPOSITORY/releases/$env:CREATED_RELEASE_ID" 2>$null) -join "`n"
+            if ($LASTEXITCODE -ne 0 -or !$releaseJson) {
+              Write-Error "无法核对待清理的 Draft Release：$env:CREATED_RELEASE_ID"
+              exit 1
+            }
+            $release = $releaseJson | ConvertFrom-Json
+          } else {
+            # The publisher failed before it could persist a numeric ID. There
+            # may be no Release yet, or gh release create may have uploaded only
+            # part of it. Recover only one exact Draft for this Tag/title;
+            # ambiguity is left for manual inspection.
+            $releasePages = @(
+              gh api --paginate --slurp "repos/$env:GITHUB_REPOSITORY/releases?per_page=100" |
+                ConvertFrom-Json
+            )
+            if ($LASTEXITCODE -ne 0) {
+              Write-Error '无法查找本次可能遗留的 Draft Release。'
+              exit 1
+            }
+            $draftMatches = @(
+              foreach ($page in $releasePages) {
+                foreach ($candidate in @($page)) {
+                  if ($candidate.draft -and
+                      $candidate.tag_name -ceq $env:RELEASE_TAG -and
+                      $candidate.name -ceq $env:GROK_VERSION) {
+                    $candidate
+                  }
+                }
+              }
+            )
+            if ($draftMatches.Count -eq 0) {
+              Write-Host '没有找到本次 Tag 的遗留 Draft Release。'
+              exit 0
+            }
+            if ($draftMatches.Count -ne 1) {
+              Write-Error "找到 $($draftMatches.Count) 个候选 Draft，拒绝自动删除。"
+              exit 1
+            }
+            $release = $draftMatches[0]
+          }
+          if ((![string]::IsNullOrWhiteSpace($env:CREATED_RELEASE_ID) -and
+               [int64]$release.id -ne [int64]$env:CREATED_RELEASE_ID) -or
+              $release.tag_name -cne $env:RELEASE_TAG -or
+              $release.name -cne $env:GROK_VERSION -or
+              ![bool]$release.draft) {
+            Write-Error '本次 Release 已发布或身份发生变化，拒绝自动删除；请人工核对。'
+            exit 1
+          }
+          $deleteId = [int64]$release.id
+          gh api --method DELETE "repos/$env:GITHUB_REPOSITORY/releases/$deleteId"
+          if ($LASTEXITCODE -ne 0) {
+            Write-Error "无法清理遗留 Draft Release：$deleteId"
+            exit 1
+          }
+          Write-Host "已清理遗留 Draft Release：$deleteId"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14559,6 +14559,7 @@ version = "0.1.220-alpha.4"
 dependencies = [
  "anyhow",
  "dunce",
+ "flate2",
  "futures",
  "indicatif",
  "libc",
@@ -14568,6 +14569,7 @@ dependencies = [
  "serde_json",
  "serial_test",
  "sha2 0.10.9",
+ "tar",
  "tempfile",
  "thiserror 2.0.18",
  "time",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14577,6 +14577,7 @@ dependencies = [
  "tracing",
  "url",
  "wiremock",
+ "xai-grok-home",
  "xai-grok-product",
  "xai-grok-shell",
  "xai-grok-telemetry",

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 本项目在尽量保持原有功能、命令行参数、配置格式和协议兼容性的前提下，为 Grok Build 的 CLI、TUI、设置、提示信息和用户文档提供简体中文支持。它以独立程序名 `grok-zh` 与官方版并行使用，但有意共用 `~/.grok` 数据目录：会话、登录状态、配置、第三方 API、插件与本地状态在两个入口之间保持一致。
 
-[项目定位](#项目定位) · [当前状态](#当前状态) · [Windows-安装](#windows-安装) · [从源码构建](#从源码构建) · [共享数据与兼容约定](#共享数据与兼容约定) · [文档](#文档) · [开发](#开发) · [Releases](https://github.com/JoyElliot/grok-build-Chinese/releases) · [上游与发布策略](#上游与发布策略) · [许可证](#许可证)
+[项目定位](#项目定位) · [当前状态](#当前状态) · [Windows-安装](#windows-安装) · [macOS-arm64-安装](#macos-arm64-安装) · [从源码构建](#从源码构建) · [共享数据与兼容约定](#共享数据与兼容约定) · [文档](#文档) · [开发](#开发) · [Releases](https://github.com/JoyElliot/grok-build-Chinese/releases) · [上游与发布策略](#上游与发布策略) · [许可证](#许可证)
 
 ![grok-zh 中文 TUI 工具链体检](docs/screenshots/grok-zh-toolchain-check.png)
 
@@ -36,7 +36,8 @@
 `zh-dev` 另提供由 GitHub 托管 Apple Silicon runner 构建的 macOS ARM64
 [预览 Artifact](https://github.com/JoyElliot/grok-build-Chinese/actions/workflows/build-macos-arm.yml)。
 该产物只用于构建与真实设备测试，尚未使用 Apple Developer ID 签名或公证，也不会独立
-创建 Release；安装和安全边界见 [macOS ARM64 预览说明](packaging/macos/INSTALL-MACOS.md)。
+创建 Release；正式 Tag 则由统一发布工作流汇总 Windows 与 macOS 资产。安装和安全边界见
+[macOS ARM64 安装说明](packaging/macos/INSTALL-MACOS.md)。
 
 已建立的产品与数据边界：
 
@@ -79,6 +80,24 @@
 - 激活失败时保留当前版本；需要同步 `agent-zh.cmd`、`rg.exe`、安装器或文档时，重新运行新 ZIP 中的安装器。
 
 旧版迁移、高级参数和恢复方式见 [Windows 自动安装说明](packaging/windows/INSTALL-WINDOWS.md)。正式 Release 同时提供 SHA-256 与 GitHub Artifact Attestation，用于核对文件完整性和云端构建来源；它们不等同于 Windows Authenticode 签名。
+
+## macOS ARM64 安装
+
+macOS 包只支持 Apple Silicon（M1 及后续机型）。解包并完成双层 SHA-256 校验后，运行：
+
+```sh
+./Install-GrokZh.sh
+```
+
+默认只创建 `grok-zh`、`agent-zh`；明确需要兼容官方命令名时，才使用
+`./Install-GrokZh.sh --with-compat-aliases`。安装器只写入 `${GROK_HOME:-$HOME/.grok}`，
+不会改 shell 配置、`/usr/local/bin` 或 macOS 安全设置。
+
+从同时包含 macOS 资产的正式 Release 起，内置更新器会校验本仓库的不可变 Release、
+外层 GitHub SHA-256、严格 USTAR 布局、包内清单和候选程序版本，再把新的不可变目标原子
+切换到 `grok-zh`/`agent-zh`。这不要求本地拥有 Xcode 或 Apple Developer ID，但当前未签名、
+未公证的构建仍可能触发 Gatekeeper。完整步骤与安全边界见
+[macOS ARM64 安装说明](packaging/macos/INSTALL-MACOS.md)。
 
 ### 反馈
 
@@ -137,7 +156,7 @@ cargo build --frozen --target x86_64-pc-windows-gnu `
 绿色测试包还会在 `grok-zh.exe` 同目录携带 `rg.exe`。社区版搜索入口优先使用该旁载工具，缺失时再回退到系统 `PATH`；这只隔离程序安装文件，不改变两个程序共用 `~/.grok` 数据的约定。
 
 正式 Windows 发布仍需补齐 MSVC 构建、代码签名、安装包和 DLL 闭包验证；社区自动更新链
-已经接入本仓库 Releases，并只消费经过双层校验的 Windows GNU 完整 ZIP。
+只消费本仓库 Releases 中经过平台资产集合、双层哈希、归档布局和候选程序版本校验的完整包。
 
 ## 共享数据与兼容约定
 
@@ -155,7 +174,7 @@ cargo build --frozen --target x86_64-pc-windows-gnu `
 ## 文档
 
 - Windows 自动安装：[`packaging/windows/INSTALL-WINDOWS.md`](packaging/windows/INSTALL-WINDOWS.md)
-- macOS ARM64 预览：[`packaging/macos/INSTALL-MACOS.md`](packaging/macos/INSTALL-MACOS.md)
+- macOS ARM64 安装与自动更新：[`packaging/macos/INSTALL-MACOS.md`](packaging/macos/INSTALL-MACOS.md)
 - 中文用户指南：[`crates/codegen/xai-grok-pager/docs/user-guide/zh-CN/README.md`](crates/codegen/xai-grok-pager/docs/user-guide/zh-CN/README.md)
 - 中文入门教程：[`crates/codegen/xai-grok-pager/docs/tutorial/zh-CN/`](crates/codegen/xai-grok-pager/docs/tutorial/zh-CN/)
 - 英文上游用户指南：[`crates/codegen/xai-grok-pager/docs/user-guide/README.md`](crates/codegen/xai-grok-pager/docs/user-guide/README.md)
@@ -206,6 +225,8 @@ cargo fmt --all
 - `zh-dev`：汉化开发、上游合并、构建和测试。
 - 计划中的 `zh-stable`：只有在中文验证通过后才建立；稳定 Release 只由指向已审核提交的
   严格三段 Tag `vA.B.C` 触发，并与上游包版本保持一致。
+- 仓库 Ruleset 必须限制 `v*` Tag 的创建、更新和删除权限，只允许维护者给已审核分支提交
+  打 Tag；工作流内的 SHA 复核不能替代 GitHub 服务端的 Tag 保护。
 - 上游 `main` 更新只能触发审查和测试，不能直接进入用户更新源。
 - GitHub 发布页正文统一使用中文；每条提交名称链接到对应的 GitHub 提交页面。若提交标题
   不是中文，必须先在 `.github/release-notes/commit-titles.zh-CN.json` 中按完整 SHA 提供

--- a/crates/codegen/xai-grok-pager-bin/src/main.rs
+++ b/crates/codegen/xai-grok-pager-bin/src/main.rs
@@ -3220,7 +3220,7 @@ mod tests {
             target_os = "windows",
             target_arch = "x86_64",
             target_env = "gnu"
-        ));
+        )) || cfg!(all(target_os = "macos", target_arch = "aarch64"));
         assert_eq!(xai_grok_update::updates_enabled(), supported_target);
         assert!(!xai_grok_update::official_update_sources_allowed());
         // Debug binaries still suppress background update checks.

--- a/crates/codegen/xai-grok-pager/src/app/cli.rs
+++ b/crates/codegen/xai-grok-pager/src/app/cli.rs
@@ -844,16 +844,45 @@ impl PagerArgs {
     }
     /// Parse CLI arguments without applying side effects.
     pub fn parse_cli() -> Self {
-        let bin_name = std::env::args()
+        Self::parse_cli_from(std::env::args_os())
+    }
+
+    fn parse_cli_from<I, T>(args: I) -> Self
+    where
+        I: IntoIterator<Item = T>,
+        T: Into<std::ffi::OsString>,
+    {
+        let mut args = args.into_iter().map(Into::into);
+        let argv0 = args
             .next()
-            .as_deref()
-            .map(std::path::Path::new)
-            .and_then(|p| p.file_name())
-            .and_then(|n| n.to_str())
-            .filter(|n| *n == xai_grok_product::CLI_NAME || *n == "grok" || *n == "agent")
-            .unwrap_or(xai_grok_product::CLI_NAME)
-            .to_owned();
-        Self::parse_from(std::iter::once(bin_name).chain(std::env::args().skip(1)))
+            .unwrap_or_else(|| std::ffi::OsString::from(xai_grok_product::CLI_NAME));
+        let invoked_name = std::path::Path::new(&argv0)
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or(xai_grok_product::CLI_NAME);
+        let invoked_stem = invoked_name
+            .get(..invoked_name.len().saturating_sub(4))
+            .filter(|_| {
+                invoked_name
+                    .get(invoked_name.len().saturating_sub(4)..)
+                    .is_some_and(|suffix| suffix.eq_ignore_ascii_case(".exe"))
+            })
+            .unwrap_or(invoked_name);
+        let normalized_stem = invoked_stem.to_ascii_lowercase();
+        let is_agent_entrypoint = matches!(normalized_stem.as_str(), "agent" | "agent-zh");
+        let recognized_entrypoint = matches!(
+            normalized_stem.as_str(),
+            "grok" | "grok-zh" | "agent" | "agent-zh"
+        );
+        let bin_name = if recognized_entrypoint {
+            argv0
+        } else {
+            std::ffi::OsString::from(xai_grok_product::CLI_NAME)
+        };
+        let normalized = std::iter::once(bin_name)
+            .chain(is_agent_entrypoint.then(|| std::ffi::OsString::from("agent")))
+            .chain(args);
+        Self::parse_from(normalized)
     }
     /// Apply launch-directory path anchoring and `--cwd` after early commands
     /// have been dispatched without filesystem or process initialization.
@@ -1055,6 +1084,38 @@ impl PagerArgs {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn agent_entrypoint_names_inject_the_agent_subcommand() {
+        for entrypoint in [
+            "agent",
+            "agent-zh",
+            "agent.exe",
+            "agent-zh.exe",
+            "AGENT-ZH.ExE",
+        ] {
+            let args = PagerArgs::parse_cli_from([entrypoint, "stdio"]);
+            let Some(Command::Agent(agent)) = args.command else {
+                panic!("{entrypoint} must dispatch the agent subcommand");
+            };
+            assert!(
+                matches!(agent.mode, Some(AgentCmd::Stdio)),
+                "{entrypoint} must preserve the agent mode arguments"
+            );
+        }
+    }
+
+    #[test]
+    fn grok_entrypoint_names_keep_normal_top_level_parsing() {
+        for entrypoint in ["grok", "grok-zh", "grok.exe", "grok-zh.exe", "GROK-ZH.ExE"] {
+            let args = PagerArgs::parse_cli_from([entrypoint, "version"]);
+            assert!(
+                matches!(args.command, Some(Command::Version { json: false })),
+                "{entrypoint} must not inject the agent subcommand"
+            );
+        }
+    }
+
     #[test]
     fn version_flags_parse_as_early_intent_without_exiting() {
         for flag in ["--version", "-v", "-V"] {

--- a/crates/codegen/xai-grok-update/Cargo.toml
+++ b/crates/codegen/xai-grok-update/Cargo.toml
@@ -23,6 +23,7 @@ tar = { workspace = true, optional = true }
 tokio = { workspace = true, features = ["fs", "process", "io-util", "macros", "time"] }
 tracing = { workspace = true }
 url = { workspace = true }
+xai-grok-home = { workspace = true }
 xai-grok-shell = { workspace = true }
 xai-grok-telemetry = { workspace = true }
 xai-grok-tools = { workspace = true }

--- a/crates/codegen/xai-grok-update/Cargo.toml
+++ b/crates/codegen/xai-grok-update/Cargo.toml
@@ -5,11 +5,12 @@ version = "0.1.220-alpha.4"
 edition.workspace = true
 
 [features]
-community-build = ["dep:sha2", "dep:zip"]
+community-build = ["dep:flate2", "dep:sha2", "dep:tar", "dep:zip"]
 
 [dependencies]
 anyhow = { workspace = true }
 futures = { workspace = true }
+flate2 = { workspace = true, optional = true }
 indicatif = { workspace = true }
 reqwest = { workspace = true }
 semver = { workspace = true }
@@ -18,6 +19,7 @@ serde_json = { workspace = true }
 sha2 = { workspace = true, optional = true }
 thiserror = { workspace = true }
 time = { workspace = true, features = ["serde"] }
+tar = { workspace = true, optional = true }
 tokio = { workspace = true, features = ["fs", "process", "io-util", "macros", "time"] }
 tracing = { workspace = true }
 url = { workspace = true }

--- a/crates/codegen/xai-grok-update/src/auto_update.rs
+++ b/crates/codegen/xai-grok-update/src/auto_update.rs
@@ -1430,7 +1430,7 @@ async fn install_community_macos_release(
     version: &str,
     asset: &crate::community_release::VerifiedAsset,
 ) -> Result<String> {
-    let home = xai_grok_shell::util::grok_home::resolve_grok_home()
+    let home = xai_grok_home::resolve_grok_home()
         .ok_or_else(|| anyhow::anyhow!("unable to resolve a user GROK_HOME"))?;
     validate_community_home_path(&home)?;
     let bin_dir = home.join("bin");
@@ -2957,7 +2957,7 @@ async fn heal_managed_install(installer: &str) {
         if installer == crate::community_release::COMMUNITY_INSTALLER {
             #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
             let bin_dir = {
-                let Some(home) = xai_grok_shell::util::grok_home::resolve_grok_home() else {
+                let Some(home) = xai_grok_home::resolve_grok_home() else {
                     return;
                 };
                 if let Err(error) = validate_community_home_path(&home) {

--- a/crates/codegen/xai-grok-update/src/auto_update.rs
+++ b/crates/codegen/xai-grok-update/src/auto_update.rs
@@ -582,6 +582,10 @@ pub async fn ensure_latest_on_disk(update_config: &UpdateConfig) -> Result<Ensur
 fn disk_version_for_installer(installer: &str) -> Option<String> {
     match installer {
         "internal" | "gh-release" => crate::version::installed_on_disk_version(),
+        #[cfg(feature = "community-build")]
+        crate::community_release::COMMUNITY_INSTALLER => {
+            crate::version::installed_on_disk_version()
+        }
         _ => None,
     }
 }
@@ -656,16 +660,18 @@ fn needs_update(current: &str, target: &str, channel: &str, allow_downgrade: boo
     })
 }
 
-/// Returns `true` for installer backends whose version source is authoritative
-/// (managed by xAI directly), meaning a pointer rollback is intentional and
-/// should trigger a client downgrade. Returns `false` for backends like npm
-/// where stale corporate registries/proxies can return arbitrarily old versions.
+/// Returns `true` for installer backends whose immutable version source is
+/// authoritative, meaning a pointer rollback is intentional and should trigger
+/// a client downgrade. Returns `false` for backends like npm where stale
+/// corporate registries/proxies can return arbitrarily old versions.
 ///
 /// Users who installed via `install.sh` are classified as `"internal"` by
 /// `get_installer()`, so they also get rollback support.
 fn installer_allows_downgrade(installer: &str) -> bool {
     match installer {
         "internal" | "gh-release" => true,
+        #[cfg(feature = "community-build")]
+        crate::community_release::COMMUNITY_INSTALLER => true,
         "npm" => false,
         _ => false,
     }
@@ -1132,11 +1138,11 @@ pub async fn run_install_script(
     })
 }
 
-/// Install from the exact complete ZIP package recorded by an immutable
+/// Install from the exact complete platform package recorded by an immutable
 /// community Release. The archive is verified against GitHub metadata, its
 /// layout and inner SHA256SUMS are checked, and the extracted executable is
-/// smoke-tested before activation. Companion files remain managed by the full
-/// Windows installer; the updater never accepts a separate raw EXE asset.
+/// smoke-tested before activation. The updater never accepts a separate raw
+/// executable asset.
 #[cfg(feature = "community-build")]
 async fn install_community_release(
     target: Option<&str>,
@@ -1144,21 +1150,22 @@ async fn install_community_release(
 ) -> Result<String> {
     crate::ensure_community_updates_enabled()?;
 
-    #[cfg(not(windows))]
-    {
-        let _ = (target, update_config);
-        anyhow::bail!("community self-update currently supports only x86_64-pc-windows-gnu");
+    let version = match target {
+        Some(version) => version.to_string(),
+        None => crate::community_release::fetch_latest_version(&update_config.channel).await?,
+    };
+    let parsed = Version::parse(&version)
+        .with_context(|| format!("invalid community release version: {version}"))?;
+    if parsed.to_string() != version || !parsed.build.is_empty() {
+        anyhow::bail!("community release version is not canonical: {version}");
+    }
+    let asset = crate::community_release::fetch_asset(&version).await?;
+    if asset.version != version {
+        anyhow::bail!("release asset version does not match the requested version");
     }
 
     #[cfg(windows)]
     {
-        let version = match target {
-            Some(version) => version.to_string(),
-            None => crate::community_release::fetch_latest_version(&update_config.channel).await?,
-        };
-        Version::parse(&version)
-            .with_context(|| format!("invalid community release version: {version}"))?;
-
         let destination = std::env::current_exe().context("locating the running grok-zh.exe")?;
         let destination_name = destination
             .file_name()
@@ -1172,18 +1179,16 @@ async fn install_community_release(
             );
         }
 
-        let asset = crate::community_release::fetch_asset(&version).await?;
-        if asset.version != version {
-            anyhow::bail!("release asset version does not match the requested version");
-        }
         let archive = unique_temp_sibling(&destination, "download.zip");
         let candidate = unique_temp_sibling(&destination, "candidate.exe");
         crate::community_release::download_verified(&asset, &archive).await?;
 
         let archive_for_extract = archive.clone();
         let candidate_for_extract = candidate.clone();
+        let asset_for_extract = asset.clone();
         let extract_result = tokio::task::spawn_blocking(move || {
             crate::community_release::extract_verified_executable(
+                &asset_for_extract,
                 &archive_for_extract,
                 &candidate_for_extract,
             )
@@ -1226,8 +1231,310 @@ async fn install_community_release(
             xai_grok_product::CLI_NAME,
             version
         );
-        Ok(version)
+        return Ok(version);
     }
+
+    #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+    {
+        return install_community_macos_release(&version, &asset).await;
+    }
+
+    #[cfg(not(any(windows, all(target_os = "macos", target_arch = "aarch64"))))]
+    {
+        let _ = asset;
+        anyhow::bail!(
+            "community self-update supports only x86_64-pc-windows-gnu and aarch64-apple-darwin"
+        );
+    }
+}
+
+#[cfg(all(
+    feature = "community-build",
+    target_os = "macos",
+    target_arch = "aarch64"
+))]
+fn ensure_private_community_dir(path: &std::path::Path) -> Result<()> {
+    use std::os::unix::fs::{DirBuilderExt, MetadataExt, PermissionsExt};
+
+    match std::fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.file_type().is_symlink() => {
+            anyhow::bail!(
+                "refusing to use a symlinked community install directory: {}",
+                path.display()
+            );
+        }
+        Ok(metadata) if !metadata.is_dir() => {
+            anyhow::bail!(
+                "community install path is not a directory: {}",
+                path.display()
+            );
+        }
+        Ok(_) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            let mut builder = std::fs::DirBuilder::new();
+            builder.mode(0o700);
+            builder.create(path).with_context(|| {
+                format!("creating community install directory {}", path.display())
+            })?;
+        }
+        Err(error) => {
+            return Err(error).with_context(|| {
+                format!("checking community install directory {}", path.display())
+            });
+        }
+    }
+
+    let metadata = std::fs::symlink_metadata(path)
+        .with_context(|| format!("re-checking community install directory {}", path.display()))?;
+    if metadata.file_type().is_symlink() || !metadata.is_dir() {
+        anyhow::bail!(
+            "community install directory changed type: {}",
+            path.display()
+        );
+    }
+    if metadata.uid() != unsafe { libc::geteuid() } {
+        anyhow::bail!(
+            "community install directory is not owned by the current user: {}",
+            path.display()
+        );
+    }
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o700))
+        .with_context(|| format!("securing community install directory {}", path.display()))?;
+    let mode = std::fs::symlink_metadata(path)?.permissions().mode() & 0o777;
+    if mode != 0o700 {
+        anyhow::bail!(
+            "community install directory is not private (mode {mode:o}): {}",
+            path.display()
+        );
+    }
+    Ok(())
+}
+
+#[cfg(all(
+    feature = "community-build",
+    target_os = "macos",
+    target_arch = "aarch64"
+))]
+fn validate_community_home_path(path: &std::path::Path) -> Result<()> {
+    use std::path::Component;
+
+    if !path.is_absolute() || path.parent().is_none() {
+        anyhow::bail!(
+            "community GROK_HOME must be an absolute non-root path: {}",
+            path.display()
+        );
+    }
+    let mut current = std::path::PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::RootDir => current.push(std::path::MAIN_SEPARATOR_STR),
+            Component::Normal(name) => current.push(name),
+            _ => {
+                anyhow::bail!(
+                    "community GROK_HOME contains an unsafe path component: {}",
+                    path.display()
+                );
+            }
+        }
+        match std::fs::symlink_metadata(&current) {
+            Ok(metadata) if metadata.file_type().is_symlink() => {
+                anyhow::bail!(
+                    "community GROK_HOME contains a symlink component: {}",
+                    current.display()
+                );
+            }
+            Ok(metadata) if !metadata.is_dir() => {
+                anyhow::bail!(
+                    "community GROK_HOME contains a non-directory component: {}",
+                    current.display()
+                );
+            }
+            Ok(_) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                // Only the final GROK_HOME component may be absent. Parent
+                // creation is deliberately forbidden so no unresolved chain
+                // can be followed by create_dir_all.
+                if current != path {
+                    anyhow::bail!(
+                        "community GROK_HOME parent does not exist: {}",
+                        current.display()
+                    );
+                }
+            }
+            Err(error) => {
+                return Err(error).with_context(|| {
+                    format!(
+                        "checking community GROK_HOME component {}",
+                        current.display()
+                    )
+                });
+            }
+        }
+    }
+    Ok(())
+}
+
+#[cfg(all(
+    feature = "community-build",
+    target_os = "macos",
+    target_arch = "aarch64"
+))]
+async fn sync_directory(path: &std::path::Path) -> Result<()> {
+    let dir = tokio::fs::File::open(path)
+        .await
+        .with_context(|| format!("opening directory for sync {}", path.display()))?;
+    dir.sync_all()
+        .await
+        .with_context(|| format!("syncing directory {}", path.display()))
+}
+
+#[cfg(all(
+    feature = "community-build",
+    target_os = "macos",
+    target_arch = "aarch64"
+))]
+fn reserve_unique_community_target(base: &std::path::Path) -> Result<std::path::PathBuf> {
+    use std::os::unix::fs::OpenOptionsExt;
+
+    for _ in 0..64 {
+        let path = unique_temp_sibling(base, "installed");
+        let mut options = std::fs::OpenOptions::new();
+        options.create_new(true).write(true).mode(0o600);
+        match options.open(&path) {
+            Ok(file) => {
+                if let Err(error) = file.sync_all() {
+                    drop(file);
+                    let _ = std::fs::remove_file(&path);
+                    return Err(error).with_context(|| {
+                        format!("syncing reserved community target {}", path.display())
+                    });
+                }
+                return Ok(path);
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(error) => {
+                return Err(error)
+                    .with_context(|| format!("reserving community target {}", path.display()));
+            }
+        }
+    }
+    anyhow::bail!("unable to reserve a unique community macOS install target")
+}
+
+#[cfg(all(
+    feature = "community-build",
+    target_os = "macos",
+    target_arch = "aarch64"
+))]
+async fn install_community_macos_release(
+    version: &str,
+    asset: &crate::community_release::VerifiedAsset,
+) -> Result<String> {
+    let home = xai_grok_shell::util::grok_home::resolve_grok_home()
+        .ok_or_else(|| anyhow::anyhow!("unable to resolve a user GROK_HOME"))?;
+    validate_community_home_path(&home)?;
+    let bin_dir = home.join("bin");
+    let download_dir = home.join("grok-zh-downloads");
+    for dir in [&home, &bin_dir, &download_dir] {
+        ensure_private_community_dir(dir)?;
+    }
+
+    let archive_base = download_dir.join(&asset.name);
+    let archive = unique_temp_sibling(&archive_base, "download");
+    let target_base = download_dir.join(format!("grok-zh-{version}-macos-aarch64"));
+    let candidate = unique_temp_sibling(&target_base, "candidate");
+
+    crate::community_release::download_verified(asset, &archive).await?;
+    let archive_for_extract = archive.clone();
+    let candidate_for_extract = candidate.clone();
+    let asset_for_extract = asset.clone();
+    let extract_result = tokio::task::spawn_blocking(move || {
+        crate::community_release::extract_verified_executable(
+            &asset_for_extract,
+            &archive_for_extract,
+            &candidate_for_extract,
+        )
+    })
+    .await;
+    let _ = tokio::fs::remove_file(&archive).await;
+    match extract_result {
+        Ok(Ok(())) => {}
+        Ok(Err(error)) => {
+            let _ = tokio::fs::remove_file(&candidate).await;
+            return Err(error).context("validating the community macOS release package");
+        }
+        Err(error) => {
+            let _ = tokio::fs::remove_file(&candidate).await;
+            anyhow::bail!("community macOS release verifier failed: {error}");
+        }
+    }
+
+    let version_output = match smoke_test_binary(&candidate).await {
+        Ok(output) => output,
+        Err(error) => {
+            let _ = tokio::fs::remove_file(&candidate).await;
+            anyhow::bail!("downloaded community macOS binary failed verification: {error}");
+        }
+    };
+    if !community_version_output_matches(&version_output, version) {
+        let _ = tokio::fs::remove_file(&candidate).await;
+        anyhow::bail!(
+            "downloaded community macOS binary reported an unexpected version: {}",
+            truncate_err(&version_output, 200)
+        );
+    }
+
+    let installed = match reserve_unique_community_target(&target_base) {
+        Ok(path) => path,
+        Err(error) => {
+            let _ = tokio::fs::remove_file(&candidate).await;
+            return Err(error);
+        }
+    };
+    if let Err(error) = tokio::fs::rename(&candidate, &installed).await {
+        let _ = tokio::fs::remove_file(&candidate).await;
+        let _ = tokio::fs::remove_file(&installed).await;
+        return Err(error).with_context(|| {
+            format!(
+                "publishing verified community binary {}",
+                installed.display()
+            )
+        });
+    }
+    if let Err(error) = sync_directory(&download_dir).await {
+        tracing::warn!(
+            path = %download_dir.display(),
+            "verified community macOS binary is installed but directory sync failed: {error:#}"
+        );
+    }
+
+    // Every install gets a fresh immutable target. Atomic link replacement
+    // changes only the two canonical entry points and deliberately keeps old
+    // targets so a still-running Mach-O process retains its executable inode.
+    if let Err(error) = swap_community_bin_links(&installed, &bin_dir).await {
+        // Do not delete `installed`: a rollback failure may have left one link
+        // pointing at it, and preserving a harmless orphan is safer than a
+        // dangling canonical entry point.
+        return Err(error).context("activating the community macOS entry points");
+    }
+    if let Err(error) = sync_directory(&bin_dir).await {
+        tracing::warn!(
+            path = %bin_dir.display(),
+            "community macOS entry points are active but directory sync failed: {error:#}"
+        );
+    }
+
+    let _ = config::update_config(|state| {
+        state.cli.installer = Some(crate::community_release::COMMUNITY_INSTALLER.to_string());
+    })
+    .await;
+    eprintln!(
+        "  已从 {}/releases 安装 {} v{}。",
+        xai_grok_product::COMMUNITY_RELEASE_REPO,
+        xai_grok_product::CLI_NAME,
+        version
+    );
+    Ok(version.to_string())
 }
 
 /// Detect the current platform (os, arch) for binary downloads.
@@ -1979,9 +2286,114 @@ async fn swap_managed_bin_links(
 ) -> Result<std::path::PathBuf> {
     let grok_name = if cfg!(windows) { "grok.exe" } else { "grok" };
     let agent_name = if cfg!(windows) { "agent.exe" } else { "agent" };
-    let grok_link = bin_dir.join(grok_name);
-    let agent_link = bin_dir.join(agent_name);
-    let link_paths: [std::path::PathBuf; 2] = [grok_link.clone(), agent_link];
+    swap_managed_entrypoint_links(binary_path, bin_dir, grok_name, agent_name, None).await
+}
+
+#[cfg(all(unix, feature = "community-build"))]
+fn managed_community_target_path(target: &std::path::Path) -> bool {
+    !target.is_absolute()
+        && target.parent() == Some(std::path::Path::new("../grok-zh-downloads"))
+        && target
+            .file_name()
+            .and_then(|name| name.to_str())
+            .and_then(crate::version::version_from_community_macos_binary_name)
+            .is_some()
+}
+
+#[cfg(all(unix, feature = "community-build"))]
+async fn validate_existing_community_entrypoint(
+    path: &std::path::Path,
+    allow_canonical_indirection: bool,
+) -> Result<()> {
+    let metadata = match tokio::fs::symlink_metadata(path).await {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => {
+            return Err(error).with_context(|| format!("checking entry point {}", path.display()));
+        }
+    };
+    if !metadata.file_type().is_symlink() {
+        anyhow::bail!(
+            "refusing to replace an unmanaged entry point: {}",
+            path.display()
+        );
+    }
+    let target = tokio::fs::read_link(path)
+        .await
+        .with_context(|| format!("reading entry point {}", path.display()))?;
+    if allow_canonical_indirection && target == std::path::Path::new("grok-zh") {
+        return Ok(());
+    }
+    if !managed_community_target_path(&target) {
+        anyhow::bail!(
+            "refusing to replace an unmanaged community link: {} -> {}",
+            path.display(),
+            target.display()
+        );
+    }
+    let resolved = path
+        .parent()
+        .ok_or_else(|| anyhow::anyhow!("entry point has no parent: {}", path.display()))?
+        .join(&target);
+    let target_metadata = tokio::fs::symlink_metadata(&resolved)
+        .await
+        .with_context(|| format!("checking managed target {}", resolved.display()))?;
+    if target_metadata.file_type().is_symlink() || !target_metadata.is_file() {
+        anyhow::bail!(
+            "managed community target is not a regular file: {}",
+            resolved.display()
+        );
+    }
+    Ok(())
+}
+
+#[cfg(all(unix, feature = "community-build"))]
+async fn swap_community_bin_links(
+    binary_path: &std::path::Path,
+    bin_dir: &std::path::Path,
+) -> Result<std::path::PathBuf> {
+    // `agent-zh` follows the canonical `grok-zh` link instead of duplicating
+    // its version target. Concurrent updaters can then race only on one
+    // version pointer; both command names always converge on the same inode.
+    let binary_target = relative_symlink_target(binary_path, &bin_dir.join("grok-zh"));
+    if !managed_community_target_path(&binary_target) {
+        anyhow::bail!(
+            "refusing to activate a community binary outside the managed download directory: {}",
+            binary_path.display()
+        );
+    }
+    let binary_metadata = tokio::fs::symlink_metadata(binary_path)
+        .await
+        .with_context(|| format!("checking community binary {}", binary_path.display()))?;
+    if binary_metadata.file_type().is_symlink() || !binary_metadata.is_file() {
+        anyhow::bail!(
+            "community binary is not a regular file: {}",
+            binary_path.display()
+        );
+    }
+    validate_existing_community_entrypoint(&bin_dir.join("grok-zh"), false).await?;
+    validate_existing_community_entrypoint(&bin_dir.join("agent-zh"), true).await?;
+
+    swap_managed_entrypoint_links(
+        binary_path,
+        bin_dir,
+        "grok-zh",
+        "agent-zh",
+        Some(std::path::Path::new("grok-zh")),
+    )
+    .await
+}
+
+async fn swap_managed_entrypoint_links(
+    binary_path: &std::path::Path,
+    bin_dir: &std::path::Path,
+    primary_name: &str,
+    secondary_name: &str,
+    secondary_target: Option<&std::path::Path>,
+) -> Result<std::path::PathBuf> {
+    let primary_link = bin_dir.join(primary_name);
+    let secondary_link = bin_dir.join(secondary_name);
+    let link_paths: [std::path::PathBuf; 2] = [primary_link.clone(), secondary_link];
 
     // Capture every link up-front so a 2nd-link capture failure can't
     // strand the 1st mid-swap.
@@ -2000,31 +2412,43 @@ async fn swap_managed_bin_links(
         }
     }
 
-    let mut completed: Vec<&LinkRollback> = Vec::with_capacity(captured.len());
+    let mut completed: Vec<(&LinkRollback, Option<std::path::PathBuf>)> =
+        Vec::with_capacity(captured.len());
     for (i, (link_path, rollback)) in link_paths.iter().zip(captured.iter()).enumerate() {
+        let target = if i == 1 {
+            secondary_target.unwrap_or(binary_path)
+        } else {
+            binary_path
+        };
         #[cfg(unix)]
         let swap_result = {
-            let rel_target = relative_symlink_target(binary_path, link_path);
+            let rel_target = relative_symlink_target(target, link_path);
             atomic_symlink_swap(&rel_target, link_path).await
         };
+        #[cfg(unix)]
+        let rollback_expected = Some(relative_symlink_target(target, link_path));
         #[cfg(windows)]
-        let swap_result = windows_replace_exe(binary_path, link_path).await;
+        let swap_result = windows_replace_exe(target, link_path).await;
+        #[cfg(windows)]
+        let rollback_expected = None;
         #[cfg(not(any(unix, windows)))]
         let swap_result: Result<()> = {
             // No managed bin layout on this target; no-op.
-            let _ = (binary_path, link_path);
+            let _ = (target, link_path);
             Ok(())
         };
+        #[cfg(not(any(unix, windows)))]
+        let rollback_expected = None;
 
         match swap_result {
-            Ok(()) => completed.push(rollback),
+            Ok(()) => completed.push((rollback, rollback_expected)),
             Err(e) => {
                 // Restore each successful swap in reverse. On restore
                 // failure keep the .rollback.bak as a recovery artifact
                 // (Windows only) and warn!; the swap error propagates so
                 // `reinstall_hint` is the user-visible message.
-                for prior in completed.iter().rev() {
-                    if let Err(restore_err) = prior.restore().await {
+                for (prior, expected) in completed.iter().rev() {
+                    if let Err(restore_err) = prior.restore(expected.as_deref()).await {
                         let backup_note = prior.backup_path().map_or(String::new(), |p| {
                             format!(" (prior binary preserved at {})", p.display())
                         });
@@ -2050,7 +2474,7 @@ async fn swap_managed_bin_links(
     for cap in &captured {
         cap.cleanup().await;
     }
-    Ok(grok_link)
+    Ok(primary_link)
 }
 
 /// Snapshot of a managed-bin link's prior state for rollback in
@@ -2138,7 +2562,25 @@ impl LinkRollback {
         None
     }
 
-    async fn restore(&self) -> Result<()> {
+    async fn restore(&self, expected_current: Option<&std::path::Path>) -> Result<()> {
+        #[cfg(not(unix))]
+        let _ = expected_current;
+        #[cfg(unix)]
+        if let Some(expected) = expected_current {
+            match tokio::fs::read_link(self.link_path()).await {
+                Ok(current) if current == expected => {}
+                Ok(_) => return Ok(()),
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+                Err(error) => {
+                    return Err(error).with_context(|| {
+                        format!(
+                            "checking current link before rollback {}",
+                            self.link_path().display()
+                        )
+                    });
+                }
+            }
+        }
         match self {
             LinkRollback::Absent { link_path } => {
                 // Remove the link we created. NotFound (someone else
@@ -2492,7 +2934,15 @@ async fn cleanup_old_downloads(dir: &std::path::Path, bin_prefix: &str, current_
 }
 
 fn installer_manages_bin_entrypoints(installer: &str) -> bool {
-    matches!(installer, "internal" | "gh-release")
+    if matches!(installer, "internal" | "gh-release") {
+        return true;
+    }
+    #[cfg(feature = "community-build")]
+    {
+        return installer == crate::community_release::COMMUNITY_INSTALLER;
+    }
+    #[cfg(not(feature = "community-build"))]
+    false
 }
 
 #[cfg_attr(not(any(unix, windows)), allow(clippy::unused_async))]
@@ -2503,8 +2953,38 @@ async fn heal_managed_install(installer: &str) {
 
     #[cfg(any(unix, windows))]
     {
-        let bin_dir = grok_home().join("bin");
+        #[cfg(feature = "community-build")]
+        if installer == crate::community_release::COMMUNITY_INSTALLER {
+            #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+            let bin_dir = {
+                let Some(home) = xai_grok_shell::util::grok_home::resolve_grok_home() else {
+                    return;
+                };
+                if let Err(error) = validate_community_home_path(&home) {
+                    tracing::warn!("refusing to reconcile an unsafe community home: {error:#}");
+                    return;
+                }
+                let bin_dir = home.join("bin");
+                let download_dir = home.join("grok-zh-downloads");
+                for dir in [&home, &bin_dir, &download_dir] {
+                    if let Err(error) = ensure_private_community_dir(dir) {
+                        tracing::warn!(
+                            path = %dir.display(),
+                            "refusing to reconcile an unsafe community install directory: {error:#}"
+                        );
+                        return;
+                    }
+                }
+                bin_dir
+            };
+            #[cfg(all(unix, not(all(target_os = "macos", target_arch = "aarch64"))))]
+            let bin_dir = grok_home().join("bin");
+            #[cfg(unix)]
+            reconcile_secondary_to_fixed_target(&bin_dir, "grok-zh", "agent-zh").await;
+            return;
+        }
 
+        let bin_dir = grok_home().join("bin");
         #[cfg(unix)]
         reconcile_agent_to_grok(&bin_dir).await;
 
@@ -2515,26 +2995,80 @@ async fn heal_managed_install(installer: &str) {
 
 #[cfg(unix)]
 async fn reconcile_agent_to_grok(bin_dir: &std::path::Path) {
-    let grok_link = bin_dir.join("grok");
-    let agent_link = bin_dir.join("agent");
+    reconcile_secondary_to_primary(bin_dir, "grok", "agent").await;
+}
 
-    let Ok(grok_target) = tokio::fs::read_link(&grok_link).await else {
-        return;
-    };
-    if tokio::fs::metadata(&grok_link).await.is_err() {
+#[cfg(all(unix, feature = "community-build"))]
+async fn reconcile_secondary_to_fixed_target(
+    bin_dir: &std::path::Path,
+    primary_name: &str,
+    secondary_name: &str,
+) {
+    let primary_link = bin_dir.join(primary_name);
+    let secondary_link = bin_dir.join(secondary_name);
+    if let Err(error) = validate_existing_community_entrypoint(&primary_link, false).await {
+        tracing::warn!(
+            "refusing to reconcile {secondary_name}: canonical {primary_name} is unmanaged: {error:#}"
+        );
         return;
     }
-    if let Ok(agent_target) = tokio::fs::read_link(&agent_link).await
-        && agent_target == grok_target
+    if tokio::fs::metadata(&primary_link).await.is_err() {
+        return;
+    }
+    let desired_target = std::path::Path::new(primary_name);
+    if let Ok(current_target) = tokio::fs::read_link(&secondary_link).await
+        && current_target == desired_target
     {
         return;
     }
-    match atomic_symlink_swap(&grok_target, &agent_link).await {
+    if let Err(error) = validate_existing_community_entrypoint(&secondary_link, true).await {
+        tracing::warn!(
+            "refusing to replace unmanaged {secondary_name} during reconciliation: {error:#}"
+        );
+        return;
+    }
+    match atomic_symlink_swap(desired_target, &secondary_link).await {
         Ok(()) => tracing::info!(
-            grok_target = %grok_target.display(),
-            "reconciled agent bin symlink to grok target"
+            primary = primary_name,
+            secondary = secondary_name,
+            "reconciled secondary bin symlink to canonical primary entry point"
         ),
-        Err(e) => tracing::warn!("failed to reconcile agent bin symlink: {e:#}"),
+        Err(error) => tracing::warn!(
+            "failed to reconcile {secondary_name} bin symlink to {primary_name}: {error:#}"
+        ),
+    }
+}
+
+#[cfg(unix)]
+async fn reconcile_secondary_to_primary(
+    bin_dir: &std::path::Path,
+    primary_name: &str,
+    secondary_name: &str,
+) {
+    let primary_link = bin_dir.join(primary_name);
+    let secondary_link = bin_dir.join(secondary_name);
+
+    let Ok(primary_target) = tokio::fs::read_link(&primary_link).await else {
+        return;
+    };
+    if tokio::fs::metadata(&primary_link).await.is_err() {
+        return;
+    }
+    if let Ok(secondary_target) = tokio::fs::read_link(&secondary_link).await
+        && secondary_target == primary_target
+    {
+        return;
+    }
+    match atomic_symlink_swap(&primary_target, &secondary_link).await {
+        Ok(()) => tracing::info!(
+            primary = primary_name,
+            secondary = secondary_name,
+            target = %primary_target.display(),
+            "reconciled secondary bin symlink to primary target"
+        ),
+        Err(e) => tracing::warn!(
+            "failed to reconcile {secondary_name} bin symlink to {primary_name}: {e:#}"
+        ),
     }
 }
 
@@ -3442,8 +3976,90 @@ mod tests {
     fn test_installer_manages_bin_entrypoints_gate() {
         assert!(installer_manages_bin_entrypoints("internal"));
         assert!(installer_manages_bin_entrypoints("gh-release"));
+        #[cfg(feature = "community-build")]
+        assert!(installer_manages_bin_entrypoints(
+            crate::community_release::COMMUNITY_INSTALLER
+        ));
         assert!(!installer_manages_bin_entrypoints("npm"));
         assert!(!installer_manages_bin_entrypoints("unknown"));
+    }
+
+    #[cfg(all(unix, feature = "community-build"))]
+    #[tokio::test]
+    async fn test_community_entrypoints_share_one_immutable_target() {
+        let dir = tempfile::tempdir().unwrap();
+        let bin = dir.path().join("bin");
+        let downloads = dir.path().join("grok-zh-downloads");
+        std::fs::create_dir_all(&bin).unwrap();
+        std::fs::create_dir_all(&downloads).unwrap();
+        let target = downloads.join("grok-zh-1.0.7-macos-aarch64.1-0.installed");
+        std::fs::write(&target, "community").unwrap();
+
+        let primary = swap_community_bin_links(&target, &bin).await.unwrap();
+
+        assert_eq!(primary, bin.join("grok-zh"));
+        for name in ["grok-zh", "agent-zh"] {
+            let link = bin.join(name);
+            assert!(link.is_symlink(), "{name} must be a symlink");
+            assert_eq!(std::fs::read_to_string(link).unwrap(), "community");
+        }
+        assert_eq!(
+            std::fs::read_link(bin.join("agent-zh")).unwrap(),
+            std::path::PathBuf::from("grok-zh")
+        );
+    }
+
+    #[cfg(all(unix, feature = "community-build"))]
+    #[tokio::test]
+    async fn test_community_entrypoints_refuse_unmanaged_existing_paths() {
+        let dir = tempfile::tempdir().unwrap();
+        let bin = dir.path().join("bin");
+        let downloads = dir.path().join("grok-zh-downloads");
+        std::fs::create_dir_all(&bin).unwrap();
+        std::fs::create_dir_all(&downloads).unwrap();
+        let target = downloads.join("grok-zh-1.0.7-macos-aarch64.1-0.installed");
+        std::fs::write(&target, "community").unwrap();
+
+        std::os::unix::fs::symlink("/tmp/unmanaged-grok", bin.join("grok-zh")).unwrap();
+        let error = swap_community_bin_links(&target, &bin).await.unwrap_err();
+        assert!(error.to_string().contains("unmanaged community link"));
+        assert_eq!(
+            std::fs::read_link(bin.join("grok-zh")).unwrap(),
+            std::path::PathBuf::from("/tmp/unmanaged-grok")
+        );
+
+        std::fs::remove_file(bin.join("grok-zh")).unwrap();
+        std::fs::write(bin.join("agent-zh"), "user file").unwrap();
+        let error = swap_community_bin_links(&target, &bin).await.unwrap_err();
+        assert!(error.to_string().contains("unmanaged entry point"));
+        assert_eq!(
+            std::fs::read_to_string(bin.join("agent-zh")).unwrap(),
+            "user file"
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_link_rollback_does_not_overwrite_a_concurrent_winner() {
+        let dir = tempfile::tempdir().unwrap();
+        let link = dir.path().join("grok");
+        std::os::unix::fs::symlink("old", &link).unwrap();
+        let rollback = LinkRollback::capture(&link).await.unwrap();
+        atomic_symlink_swap(std::path::Path::new("ours"), &link)
+            .await
+            .unwrap();
+        atomic_symlink_swap(std::path::Path::new("winner"), &link)
+            .await
+            .unwrap();
+
+        rollback
+            .restore(Some(std::path::Path::new("ours")))
+            .await
+            .unwrap();
+        assert_eq!(
+            std::fs::read_link(&link).unwrap(),
+            std::path::PathBuf::from("winner")
+        );
     }
 
     #[cfg(unix)]
@@ -4776,6 +5392,14 @@ mod tests {
     #[test]
     fn test_installer_allows_downgrade_gh_release() {
         assert!(installer_allows_downgrade("gh-release"));
+    }
+
+    #[cfg(feature = "community-build")]
+    #[test]
+    fn test_installer_allows_downgrade_community_release() {
+        assert!(installer_allows_downgrade(
+            crate::community_release::COMMUNITY_INSTALLER
+        ));
     }
 
     #[test]

--- a/crates/codegen/xai-grok-update/src/community_release.rs
+++ b/crates/codegen/xai-grok-update/src/community_release.rs
@@ -6,7 +6,7 @@
 
 use std::collections::{HashMap, HashSet};
 use std::fs::{File, OpenOptions};
-use std::io::{Read, Write};
+use std::io::{BufReader, Read, Write};
 use std::path::Path;
 use std::time::Duration;
 
@@ -29,11 +29,12 @@ const MAX_ARCHIVE_ENTRIES: usize = 128;
 const MAX_UNCOMPRESSED_BYTES: u64 = 768 * 1024 * 1024;
 const MAX_ENTRY_BYTES: u64 = 512 * 1024 * 1024;
 const MAX_MANIFEST_BYTES: u64 = 64 * 1024;
+const MAX_TAR_ZERO_PADDING_BYTES: u64 = 1024 * 1024;
 const DOWNLOAD_PROGRESS_TEMPLATE: &str =
     "  下载更新 {bar:30.cyan/dim} {bytes}/{total_bytes} {percent}% ({bytes_per_sec}，剩余 {eta})";
 const ONE_CLICK_INSTALLER: &str = "一键安装.cmd";
 const COMMAND_SETUP_INSTALLER: &str = "[可选]替换原始启动方式.cmd";
-const REQUIRED_PACKAGE_FILES: [&str; 7] = [
+const WINDOWS_REQUIRED_PACKAGE_FILES: [&str; 15] = [
     "grok-zh.exe",
     "agent-zh.cmd",
     "rg.exe",
@@ -41,7 +42,29 @@ const REQUIRED_PACKAGE_FILES: [&str; 7] = [
     COMMAND_SETUP_INSTALLER,
     "Install-GrokZh.ps1",
     "INSTALL-WINDOWS.md",
+    "LICENSE-grok-build.txt",
+    "BUILD-INFO.txt",
+    "licenses/ripgrep/COPYING",
+    "licenses/ripgrep/LICENSE-MIT",
+    "licenses/ripgrep/UNLICENSE",
+    "licenses/project/THIRD-PARTY-NOTICES",
+    "licenses/project/THIRD_PARTY_NOTICES.md",
+    "licenses/project/NOTICE",
 ];
+const WINDOWS_APPROVED_PACKAGE_DIRS: [&str; 3] =
+    ["licenses", "licenses/ripgrep", "licenses/project"];
+const MACOS_REQUIRED_PACKAGE_FILES: [&str; 9] = [
+    "grok-zh",
+    "BUILD-INFO.txt",
+    "INSTALL-MACOS.md",
+    "Install-GrokZh.sh",
+    "LICENSE-grok-build.txt",
+    "NOTICE-third-party.txt",
+    "SOURCE_REV",
+    "THIRD-PARTY-NOTICES.txt",
+    "THIRD-PARTY-NOTICES-xai-grok-tools.md",
+];
+const INNER_MANIFEST: &str = "SHA256SUMS.txt";
 
 fn is_allowed_unicode_package_name(name: &str) -> bool {
     name == ONE_CLICK_INSTALLER || name == COMMAND_SETUP_INSTALLER
@@ -94,6 +117,35 @@ pub(crate) struct VerifiedAsset {
     download_url: String,
     size: u64,
     sha256: String,
+    archive_kind: CommunityArchiveKind,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CommunityArchiveKind {
+    WindowsZip,
+    MacosTarGz,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CommunityPlatform {
+    WindowsX86_64Gnu,
+    MacosAarch64,
+}
+
+fn current_community_platform() -> Result<CommunityPlatform> {
+    if cfg!(all(
+        target_os = "windows",
+        target_arch = "x86_64",
+        target_env = "gnu"
+    )) {
+        Ok(CommunityPlatform::WindowsX86_64Gnu)
+    } else if cfg!(all(target_os = "macos", target_arch = "aarch64")) {
+        Ok(CommunityPlatform::MacosAarch64)
+    } else {
+        anyhow::bail!(
+            "community self-update supports only x86_64-pc-windows-gnu and aarch64-apple-darwin"
+        )
+    }
 }
 
 fn github_client(request_timeout: Duration) -> Result<reqwest::Client> {
@@ -196,20 +248,49 @@ pub(crate) async fn fetch_latest_version(channel: &str) -> Result<String> {
             break;
         }
     }
-    let (_, version) = select_latest_release(&releases, channel)?;
+    let platform = current_community_platform()?;
+    let (_, version) = select_latest_compatible_release(&releases, channel, platform)?;
     Ok(version.to_string())
 }
 
-fn release_asset_name(version: &str) -> Result<String> {
+fn canonical_release_version(version: &str) -> Result<Version> {
     let parsed = Version::parse(version)
         .with_context(|| format!("invalid community release version: {version}"))?;
     if parsed.to_string() != version || !parsed.build.is_empty() {
         anyhow::bail!("community release version is not canonical: {version}");
     }
-    if !(cfg!(target_os = "windows") && cfg!(target_arch = "x86_64") && cfg!(target_env = "gnu")) {
-        anyhow::bail!("community self-update currently supports only x86_64-pc-windows-gnu");
+    Ok(parsed)
+}
+
+fn release_asset_name_for(platform: CommunityPlatform, version: &str) -> Result<String> {
+    canonical_release_version(version)?;
+    match platform {
+        CommunityPlatform::WindowsX86_64Gnu => {
+            Ok(format!("grok-zh-{version}-windows-x86_64-gnu.zip"))
+        }
+        CommunityPlatform::MacosAarch64 => Ok(format!("grok-zh-{version}-macos-aarch64.tar.gz")),
     }
-    Ok(format!("grok-zh-{version}-windows-x86_64-gnu.zip"))
+}
+
+fn release_asset_name(version: &str) -> Result<String> {
+    release_asset_name_for(current_community_platform()?, version)
+}
+
+fn release_includes_macos_assets(version: &Version) -> bool {
+    (version.major, version.minor, version.patch) >= (1, 0, 7)
+}
+
+fn expected_release_asset_names(version: &str) -> Result<Vec<String>> {
+    let parsed = canonical_release_version(version)?;
+    let windows = release_asset_name_for(CommunityPlatform::WindowsX86_64Gnu, version)?;
+    let mut names = vec![windows.clone(), format!("{windows}.sha256")];
+    if release_includes_macos_assets(&parsed) {
+        let macos = release_asset_name_for(CommunityPlatform::MacosAarch64, version)?;
+        names.push(macos.clone());
+        names.push(format!("{macos}.sha256"));
+    }
+    names.sort_unstable();
+    Ok(names)
 }
 
 fn parse_sha256_digest(value: &str) -> Result<String> {
@@ -222,13 +303,20 @@ fn parse_sha256_digest(value: &str) -> Result<String> {
     Ok(digest.to_ascii_lowercase())
 }
 
-fn select_asset(release: &ApiRelease, version: &str) -> Result<VerifiedAsset> {
+fn select_asset_for_platform(
+    release: &ApiRelease,
+    version: &str,
+    platform: CommunityPlatform,
+) -> Result<VerifiedAsset> {
     let parsed = parse_release_version(release)
         .ok_or_else(|| anyhow::anyhow!("release is mutable, draft, or has invalid metadata"))?;
     if parsed.to_string() != version || release.tag_name != format!("v{version}") {
         anyhow::bail!("release tag and requested version do not match");
     }
-    let name = release_asset_name(version)?;
+    let name = release_asset_name_for(platform, version)?;
+    if platform == CommunityPlatform::MacosAarch64 && !release_includes_macos_assets(&parsed) {
+        anyhow::bail!("release {version} predates macOS community self-update support");
+    }
     let sidecar_name = format!("{name}.sha256");
     let mut actual_names: Vec<&str> = release
         .assets
@@ -237,12 +325,37 @@ fn select_asset(release: &ApiRelease, version: &str) -> Result<VerifiedAsset> {
         .map(|asset| asset.name.as_str())
         .collect();
     actual_names.sort_unstable();
-    let mut expected_names = vec![name.as_str(), sidecar_name.as_str()];
-    expected_names.sort_unstable();
-    if release.assets.len() != 2 || actual_names != expected_names {
-        anyhow::bail!(
-            "release assets must be exactly {name} and {sidecar_name}; raw executables are not accepted"
+    let expected_names = expected_release_asset_names(version)?;
+    let expected_name_refs: Vec<&str> = expected_names.iter().map(String::as_str).collect();
+    if release.assets.len() != expected_names.len() || actual_names != expected_name_refs {
+        anyhow::bail!("release assets do not match the exact approved platform asset set");
+    }
+    for expected_name in &expected_names {
+        let expected = release
+            .assets
+            .iter()
+            .find(|asset| asset.name == *expected_name)
+            .ok_or_else(|| anyhow::anyhow!("release is missing {expected_name}"))?;
+        let is_sidecar = expected_name.ends_with(".sha256");
+        let max_size = if is_sidecar {
+            MAX_SIDECAR_BYTES
+        } else {
+            MAX_ASSET_BYTES
+        };
+        if expected.size == 0 || expected.size > max_size {
+            anyhow::bail!("release asset size is outside the accepted range: {expected_name}");
+        }
+        let expected_url = format!(
+            "https://github.com/{}/releases/download/v{version}/{expected_name}",
+            release_repo()
         );
+        if expected.browser_download_url != expected_url {
+            anyhow::bail!("release asset URL does not match the fixed community repository");
+        }
+        let digest = expected.digest.as_deref().ok_or_else(|| {
+            anyhow::anyhow!("release asset is missing its GitHub SHA-256 digest: {expected_name}")
+        })?;
+        parse_sha256_digest(digest)?;
     }
     let asset = release
         .assets
@@ -254,12 +367,6 @@ fn select_asset(release: &ApiRelease, version: &str) -> Result<VerifiedAsset> {
         .iter()
         .find(|asset| asset.name == sidecar_name)
         .ok_or_else(|| anyhow::anyhow!("release is missing {sidecar_name}"))?;
-    if asset.size == 0 || asset.size > MAX_ASSET_BYTES {
-        anyhow::bail!("release asset size is outside the accepted range");
-    }
-    if sidecar.size == 0 || sidecar.size > MAX_SIDECAR_BYTES {
-        anyhow::bail!("release checksum sidecar size is outside the accepted range");
-    }
     let expected_url = format!(
         "https://github.com/{}/releases/download/v{version}/{name}",
         release_repo()
@@ -289,6 +396,43 @@ fn select_asset(release: &ApiRelease, version: &str) -> Result<VerifiedAsset> {
         download_url: expected_url,
         size: asset.size,
         sha256: parse_sha256_digest(digest)?,
+        archive_kind: match platform {
+            CommunityPlatform::WindowsX86_64Gnu => CommunityArchiveKind::WindowsZip,
+            CommunityPlatform::MacosAarch64 => CommunityArchiveKind::MacosTarGz,
+        },
+    })
+}
+
+fn select_asset(release: &ApiRelease, version: &str) -> Result<VerifiedAsset> {
+    select_asset_for_platform(release, version, current_community_platform()?)
+}
+
+fn select_latest_compatible_release<'a>(
+    releases: &'a [ApiRelease],
+    channel: &str,
+    platform: CommunityPlatform,
+) -> Result<(&'a ApiRelease, Version)> {
+    let mut compatible = releases
+        .iter()
+        .filter_map(|release| {
+            let version = parse_release_version(release)?;
+            if channel == "stable" && !version.pre.is_empty() {
+                return None;
+            }
+            select_asset_for_platform(release, &version.to_string(), platform)
+                .ok()
+                .map(|_| (release, version))
+        })
+        .collect::<Vec<_>>();
+    if !matches!(channel, "stable" | "alpha") {
+        anyhow::bail!("unsupported community release channel: {channel}");
+    }
+    compatible.sort_by(|(_, a), (_, b)| a.cmp(b));
+    compatible.pop().ok_or_else(|| {
+        anyhow::anyhow!(
+            "no immutable {channel} release compatible with this platform is available in {}",
+            release_repo()
+        )
     })
 }
 
@@ -408,12 +552,50 @@ fn finish_download_progress(progress: &ProgressBar, succeeded: bool) {
     }
 }
 
-fn validate_archive_layout(archive: &mut zip::ZipArchive<File>) -> Result<()> {
+fn normalized_package_name(name: &str) -> String {
+    if name.is_ascii() {
+        name.to_ascii_lowercase()
+    } else {
+        name.to_string()
+    }
+}
+
+fn is_safe_package_relative_path(name: &str) -> bool {
+    !name.is_empty()
+        && name.trim() == name
+        && !name.starts_with('/')
+        && !name.contains('\\')
+        && !name.contains(':')
+        && name
+            .split('/')
+            .all(|component| !component.is_empty() && !matches!(component, "." | ".."))
+}
+
+fn expected_archive_names(required_files: &[&str]) -> HashSet<String> {
+    required_files
+        .iter()
+        .copied()
+        .chain(std::iter::once(INNER_MANIFEST))
+        .map(normalized_package_name)
+        .collect()
+}
+
+fn validate_archive_layout(
+    archive: &mut zip::ZipArchive<File>,
+    required_files: &[&str],
+) -> Result<()> {
     if archive.is_empty() || archive.len() > MAX_ARCHIVE_ENTRIES {
         anyhow::bail!("community release ZIP contains an invalid number of entries");
     }
 
-    let mut seen = HashSet::new();
+    let expected_files = expected_archive_names(required_files);
+    let approved_dirs: HashSet<String> = WINDOWS_APPROVED_PACKAGE_DIRS
+        .iter()
+        .copied()
+        .map(normalized_package_name)
+        .collect();
+    let mut seen_files = HashSet::new();
+    let mut seen_dirs = HashSet::new();
     let mut total_size = 0u64;
     for index in 0..archive.len() {
         let entry = archive
@@ -448,15 +630,23 @@ fn validate_archive_layout(archive: &mut zip::ZipArchive<File>) -> Result<()> {
         }
 
         let enclosed_text = enclosed.to_string_lossy();
-        if !enclosed_text.is_ascii() && !is_allowed_unicode_package_name(&enclosed_text) {
+        let enclosed_name = enclosed_text.strip_suffix('/').unwrap_or(&enclosed_text);
+        if !enclosed_name.is_ascii() && !is_allowed_unicode_package_name(enclosed_name) {
             anyhow::bail!(
                 "community release ZIP entry name contains unapproved Unicode: {raw_name}"
             );
         }
-        let normalized = if enclosed_text.is_ascii() {
-            enclosed_text.replace('\\', "/").to_ascii_lowercase()
+        let normalized = normalized_package_name(&enclosed_name.replace('\\', "/"));
+        let seen = if entry.is_dir() {
+            if !approved_dirs.contains(&normalized) {
+                anyhow::bail!("community release ZIP contains an extra directory: {raw_name}");
+            }
+            &mut seen_dirs
         } else {
-            enclosed_text.to_string()
+            if !expected_files.contains(&normalized) {
+                anyhow::bail!("community release ZIP contains an extra file: {raw_name}");
+            }
+            &mut seen_files
         };
         if !seen.insert(normalized) {
             anyhow::bail!("community release ZIP contains a duplicate path: {raw_name}");
@@ -469,26 +659,18 @@ fn validate_archive_layout(archive: &mut zip::ZipArchive<File>) -> Result<()> {
             anyhow::bail!("community release ZIP must not contain a nested ZIP: {raw_name}");
         }
     }
+    if seen_files != expected_files {
+        anyhow::bail!("community release ZIP does not contain the exact approved package files");
+    }
     Ok(())
 }
 
-fn read_inner_manifest(archive: &mut zip::ZipArchive<File>) -> Result<HashMap<String, String>> {
-    let entry = archive
-        .by_name("SHA256SUMS.txt")
-        .context("community release ZIP is missing SHA256SUMS.txt")?;
-    if entry.is_symlink() || !entry.is_file() || entry.size() > MAX_MANIFEST_BYTES {
-        anyhow::bail!("community release SHA256SUMS.txt is not a bounded regular file");
-    }
-    let mut bytes = Vec::with_capacity(entry.size() as usize);
-    entry
-        .take(MAX_MANIFEST_BYTES + 1)
-        .read_to_end(&mut bytes)
-        .context("reading community release SHA256SUMS.txt")?;
+fn parse_inner_manifest(bytes: &[u8], required_files: &[&str]) -> Result<HashMap<String, String>> {
     if bytes.len() as u64 > MAX_MANIFEST_BYTES {
         anyhow::bail!("community release SHA256SUMS.txt exceeds the size limit");
     }
     let text =
-        std::str::from_utf8(&bytes).context("community release SHA256SUMS.txt is not UTF-8")?;
+        std::str::from_utf8(bytes).context("community release SHA256SUMS.txt is not UTF-8")?;
     let text = text.strip_prefix('\u{feff}').unwrap_or(text);
 
     let mut hashes = HashMap::new();
@@ -512,37 +694,51 @@ fn read_inner_manifest(archive: &mut zip::ZipArchive<File>) -> Result<HashMap<St
                 line_index + 1
             );
         }
-        if name.is_empty()
-            || name.trim() != name
+        if !is_safe_package_relative_path(name)
+            || !required_files.contains(&name)
             || (!name.is_ascii() && !is_allowed_unicode_package_name(name))
-            || !REQUIRED_PACKAGE_FILES.contains(&name)
-            || name.contains(':')
-            || name.contains('/')
-            || name.contains('\\')
-            || matches!(name, "." | "..")
         {
             anyhow::bail!(
                 "community release SHA256SUMS.txt line {} has an unsafe filename",
                 line_index + 1
             );
         }
-        let normalized = if name.is_ascii() {
-            name.to_ascii_lowercase()
-        } else {
-            name.to_string()
-        };
-        if !normalized_names.insert(normalized) {
+        if !normalized_names.insert(normalized_package_name(name)) {
             anyhow::bail!("community release SHA256SUMS.txt contains a duplicate filename");
         }
         hashes.insert(name.to_string(), digest.to_ascii_lowercase());
     }
 
-    for required in REQUIRED_PACKAGE_FILES {
-        if !hashes.contains_key(required) {
+    if hashes.len() != required_files.len() {
+        anyhow::bail!("community release manifest does not contain the exact approved file set");
+    }
+    for required in required_files {
+        if !hashes.contains_key(*required) {
             anyhow::bail!("community release manifest is missing required file {required}");
         }
     }
     Ok(hashes)
+}
+
+fn read_inner_manifest(
+    archive: &mut zip::ZipArchive<File>,
+    required_files: &[&str],
+) -> Result<HashMap<String, String>> {
+    let entry = archive
+        .by_name(INNER_MANIFEST)
+        .context("community release ZIP is missing SHA256SUMS.txt")?;
+    if entry.is_symlink() || !entry.is_file() || entry.size() > MAX_MANIFEST_BYTES {
+        anyhow::bail!("community release SHA256SUMS.txt is not a bounded regular file");
+    }
+    let mut bytes = Vec::with_capacity(entry.size() as usize);
+    entry
+        .take(MAX_MANIFEST_BYTES + 1)
+        .read_to_end(&mut bytes)
+        .context("reading community release SHA256SUMS.txt")?;
+    if bytes.len() as u64 > MAX_MANIFEST_BYTES {
+        anyhow::bail!("community release SHA256SUMS.txt exceeds the size limit");
+    }
+    parse_inner_manifest(&bytes, required_files)
 }
 
 fn hash_manifest_entry(
@@ -608,7 +804,7 @@ fn hash_manifest_entry(
 /// to a new sibling file. Companion files remain managed by the full Windows
 /// installer; they are nevertheless required and hashed here so a partial or
 /// malformed package can never activate its executable.
-pub(crate) fn extract_verified_executable(archive_path: &Path, destination: &Path) -> Result<()> {
+fn extract_verified_windows_executable(archive_path: &Path, destination: &Path) -> Result<()> {
     if std::fs::symlink_metadata(destination).is_ok() {
         anyhow::bail!(
             "refusing to overwrite an existing extraction target: {}",
@@ -620,8 +816,8 @@ pub(crate) fn extract_verified_executable(archive_path: &Path, destination: &Pat
             .with_context(|| format!("opening community release ZIP {}", archive_path.display()))?;
         let mut archive = zip::ZipArchive::new(archive_file)
             .context("opening the downloaded community release as ZIP")?;
-        validate_archive_layout(&mut archive)?;
-        let hashes = read_inner_manifest(&mut archive)?;
+        validate_archive_layout(&mut archive, &WINDOWS_REQUIRED_PACKAGE_FILES)?;
+        let hashes = read_inner_manifest(&mut archive, &WINDOWS_REQUIRED_PACKAGE_FILES)?;
         for (name, expected) in hashes {
             let extracted = (name == "grok-zh.exe").then_some(destination);
             let actual = hash_manifest_entry(&mut archive, &name, extracted)?;
@@ -638,6 +834,283 @@ pub(crate) fn extract_verified_executable(archive_path: &Path, destination: &Pat
         let _ = std::fs::remove_file(destination);
     }
     result
+}
+
+fn normalized_macos_tar_name(raw: &[u8]) -> Result<Option<&str>> {
+    if !raw.is_ascii() {
+        anyhow::bail!("community release tar path is not ASCII");
+    }
+    let raw = std::str::from_utf8(raw).context("community release tar path is not UTF-8")?;
+    if raw == "." || raw == "./" {
+        return Ok(None);
+    }
+    if raw.is_empty()
+        || raw.starts_with('/')
+        || raw.contains('\\')
+        || raw.contains(':')
+        || raw.bytes().any(|byte| byte.is_ascii_control())
+    {
+        anyhow::bail!("community release tar contains an unsafe raw path: {raw}");
+    }
+    let name = raw.strip_prefix("./").unwrap_or(raw);
+    if name.is_empty() || name.contains('/') || matches!(name, "." | "..") || name.starts_with("./")
+    {
+        anyhow::bail!("community release tar contains a nested or unsafe path: {raw}");
+    }
+    Ok(Some(name))
+}
+
+fn hash_tar_entry<R: Read>(
+    entry: &mut tar::Entry<'_, R>,
+    name: &str,
+    destination: Option<&Path>,
+) -> Result<String> {
+    let declared_size = entry.size();
+    if declared_size > MAX_ENTRY_BYTES {
+        anyhow::bail!("community release tar entry is too large: {name}");
+    }
+    let mut output = match destination {
+        Some(path) => {
+            let mut options = OpenOptions::new();
+            options.create_new(true).write(true);
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::OpenOptionsExt;
+                options.mode(0o600);
+            }
+            Some(
+                options
+                    .open(path)
+                    .with_context(|| format!("creating extracted candidate {}", path.display()))?,
+            )
+        }
+        None => None,
+    };
+    let mut hasher = Sha256::new();
+    let mut copied = 0u64;
+    let mut buffer = [0u8; 64 * 1024];
+    loop {
+        let read = entry
+            .read(&mut buffer)
+            .with_context(|| format!("reading {name} from community release tar"))?;
+        if read == 0 {
+            break;
+        }
+        copied = copied
+            .checked_add(read as u64)
+            .ok_or_else(|| anyhow::anyhow!("community release tar entry size overflow"))?;
+        if copied > declared_size || copied > MAX_ENTRY_BYTES {
+            anyhow::bail!("community release tar entry exceeded its declared size: {name}");
+        }
+        hasher.update(&buffer[..read]);
+        if let Some(output) = output.as_mut() {
+            output
+                .write_all(&buffer[..read])
+                .with_context(|| format!("writing extracted candidate {name}"))?;
+        }
+    }
+    if copied != declared_size {
+        anyhow::bail!("community release tar entry was truncated: {name}");
+    }
+    if let Some(mut output) = output {
+        output.flush()?;
+        output.sync_all()?;
+    }
+    Ok(hasher
+        .finalize()
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect())
+}
+
+fn extract_verified_macos_executable(archive_path: &Path, destination: &Path) -> Result<()> {
+    if std::fs::symlink_metadata(destination).is_ok() {
+        anyhow::bail!(
+            "refusing to overwrite an existing extraction target: {}",
+            destination.display()
+        );
+    }
+    let result = (|| {
+        let archive_file = File::open(archive_path).with_context(|| {
+            format!(
+                "opening community release tar.gz {}",
+                archive_path.display()
+            )
+        })?;
+        // The bufread single-member decoder stops exactly at the first gzip
+        // member. After validating the tar stream we inspect its underlying
+        // reader, so even an empty concatenated member is rejected.
+        let decoder = flate2::bufread::GzDecoder::new(BufReader::new(archive_file));
+        let mut archive = tar::Archive::new(decoder);
+        let mut entries = archive
+            .entries()
+            .context("opening the downloaded community release as tar")?
+            .raw(true);
+        let expected = expected_archive_names(&MACOS_REQUIRED_PACKAGE_FILES);
+        let mut seen = HashSet::new();
+        let mut hashes = HashMap::new();
+        let mut manifest = None;
+        let mut root_seen = false;
+        let mut count = 0usize;
+        let mut total_size = 0u64;
+
+        for entry_result in &mut entries {
+            count = count
+                .checked_add(1)
+                .ok_or_else(|| anyhow::anyhow!("community release tar entry count overflow"))?;
+            if count > MAX_ARCHIVE_ENTRIES {
+                anyhow::bail!("community release tar contains too many entries");
+            }
+            let mut entry = entry_result.context("reading community release tar entry")?;
+            if entry.header().as_ustar().is_none() {
+                anyhow::bail!("community release tar must use the USTAR format");
+            }
+            let raw_path = entry.header().path_bytes();
+            let name = normalized_macos_tar_name(raw_path.as_ref())?;
+            let entry_type = entry.header().entry_type();
+            if name.is_none() {
+                if root_seen || !entry_type.is_dir() || entry.size() != 0 {
+                    anyhow::bail!("community release tar contains an invalid root entry");
+                }
+                root_seen = true;
+                continue;
+            }
+            let name = name.expect("checked above").to_string();
+            if !entry_type.is_file() || entry.link_name_bytes().is_some() {
+                anyhow::bail!("community release tar contains a non-regular entry: {name}");
+            }
+            if entry.size() > MAX_ENTRY_BYTES {
+                anyhow::bail!("community release tar entry is too large: {name}");
+            }
+            total_size = total_size
+                .checked_add(entry.size())
+                .ok_or_else(|| anyhow::anyhow!("community release tar size overflow"))?;
+            if total_size > MAX_UNCOMPRESSED_BYTES {
+                anyhow::bail!("community release tar exceeds the uncompressed size limit");
+            }
+            let mode = entry
+                .header()
+                .mode()
+                .with_context(|| format!("reading mode for tar entry {name}"))?;
+            let expected_mode = if matches!(name.as_str(), "grok-zh" | "Install-GrokZh.sh") {
+                0o755
+            } else {
+                0o644
+            };
+            if mode & 0o7777 != expected_mode {
+                anyhow::bail!("community release tar entry has an unexpected mode: {name}");
+            }
+            let normalized = normalized_package_name(&name);
+            if !expected.contains(&normalized) || !seen.insert(normalized) {
+                anyhow::bail!("community release tar contains an extra or duplicate path: {name}");
+            }
+            if name == INNER_MANIFEST {
+                let manifest_size = entry.size();
+                if manifest_size > MAX_MANIFEST_BYTES {
+                    anyhow::bail!("community release SHA256SUMS.txt exceeds the size limit");
+                }
+                let mut bytes = Vec::with_capacity(manifest_size as usize);
+                entry
+                    .take(MAX_MANIFEST_BYTES + 1)
+                    .read_to_end(&mut bytes)
+                    .context("reading community release SHA256SUMS.txt")?;
+                if bytes.len() as u64 != manifest_size {
+                    anyhow::bail!("community release SHA256SUMS.txt was truncated");
+                }
+                manifest = Some(bytes);
+            } else {
+                let extracted = (name == "grok-zh").then_some(destination);
+                hashes.insert(name.clone(), hash_tar_entry(&mut entry, &name, extracted)?);
+            }
+        }
+        drop(entries);
+        let mut decoder = archive.into_inner();
+        // `tar::Archive::entries` consumes the first zero header and stops. A
+        // valid tar must contain a second 512-byte zero header; the remainder
+        // may only be bounded zero record padding.
+        let mut decoded_tail = [0u8; 8 * 1024];
+        let mut padding_bytes = 0u64;
+        loop {
+            let read = decoder
+                .read(&mut decoded_tail)
+                .context("validating the end of the community release gzip stream")?;
+            if read == 0 {
+                break;
+            }
+            padding_bytes = padding_bytes
+                .checked_add(read as u64)
+                .ok_or_else(|| anyhow::anyhow!("community release tar padding overflow"))?;
+            if padding_bytes > MAX_TAR_ZERO_PADDING_BYTES
+                || decoded_tail[..read].iter().any(|byte| *byte != 0)
+            {
+                anyhow::bail!("community release tar.gz contains trailing decoded data");
+            }
+        }
+        if padding_bytes < 512 {
+            anyhow::bail!("community release tar is missing its complete end marker");
+        }
+        let mut compressed_reader = decoder.into_inner();
+        let mut compressed_tail = [0u8; 1];
+        if compressed_reader
+            .read(&mut compressed_tail)
+            .context("validating the end of the community release gzip member")?
+            != 0
+        {
+            anyhow::bail!("community release tar.gz contains a concatenated or trailing stream");
+        }
+        if !root_seen {
+            anyhow::bail!("community release tar is missing its root directory entry");
+        }
+        if seen != expected {
+            anyhow::bail!(
+                "community release tar does not contain the exact approved package files"
+            );
+        }
+        let manifest = parse_inner_manifest(
+            manifest.as_deref().ok_or_else(|| {
+                anyhow::anyhow!("community release tar is missing SHA256SUMS.txt")
+            })?,
+            &MACOS_REQUIRED_PACKAGE_FILES,
+        )?;
+        for (name, expected_hash) in manifest {
+            let actual = hashes
+                .get(&name)
+                .ok_or_else(|| anyhow::anyhow!("community release tar is missing {name}"))?;
+            if actual != &expected_hash {
+                anyhow::bail!("community release inner SHA-256 mismatch for {name}");
+            }
+        }
+        if !destination.is_file() {
+            anyhow::bail!("community release did not produce grok-zh");
+        }
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(destination, std::fs::Permissions::from_mode(0o755))?;
+        }
+        #[cfg(unix)]
+        File::open(destination)?.sync_all()?;
+        Ok(())
+    })();
+    if result.is_err() {
+        let _ = std::fs::remove_file(destination);
+    }
+    result
+}
+
+pub(crate) fn extract_verified_executable(
+    asset: &VerifiedAsset,
+    archive_path: &Path,
+    destination: &Path,
+) -> Result<()> {
+    match asset.archive_kind {
+        CommunityArchiveKind::WindowsZip => {
+            extract_verified_windows_executable(archive_path, destination)
+        }
+        CommunityArchiveKind::MacosTarGz => {
+            extract_verified_macos_executable(archive_path, destination)
+        }
+    }
 }
 
 #[cfg(test)]
@@ -710,7 +1183,6 @@ mod tests {
         }
     }
 
-    #[cfg(all(target_os = "windows", target_arch = "x86_64", target_env = "gnu"))]
     fn uploaded_asset(version: &str, name: String, size: u64) -> ApiAsset {
         ApiAsset {
             browser_download_url: format!(
@@ -724,13 +1196,15 @@ mod tests {
         }
     }
 
-    #[cfg(all(target_os = "windows", target_arch = "x86_64", target_env = "gnu"))]
     fn uploaded_package_assets(version: &str) -> Vec<ApiAsset> {
-        let zip_name = format!("grok-zh-{version}-windows-x86_64-gnu.zip");
-        vec![
-            uploaded_asset(version, zip_name.clone(), 123),
-            uploaded_asset(version, format!("{zip_name}.sha256"), 112),
-        ]
+        expected_release_asset_names(version)
+            .unwrap()
+            .into_iter()
+            .map(|name| {
+                let size = if name.ends_with(".sha256") { 112 } else { 123 };
+                uploaded_asset(version, name, size)
+            })
+            .collect()
     }
 
     fn sha256_hex(bytes: &[u8]) -> String {
@@ -761,6 +1235,35 @@ mod tests {
                 "INSTALL-WINDOWS.md".to_string(),
                 b"installation guide".to_vec(),
             ),
+            (
+                "LICENSE-grok-build.txt".to_string(),
+                b"project license".to_vec(),
+            ),
+            ("BUILD-INFO.txt".to_string(), b"build metadata".to_vec()),
+            (
+                "licenses/ripgrep/COPYING".to_string(),
+                b"ripgrep copying".to_vec(),
+            ),
+            (
+                "licenses/ripgrep/LICENSE-MIT".to_string(),
+                b"ripgrep MIT license".to_vec(),
+            ),
+            (
+                "licenses/ripgrep/UNLICENSE".to_string(),
+                b"ripgrep unlicense".to_vec(),
+            ),
+            (
+                "licenses/project/THIRD-PARTY-NOTICES".to_string(),
+                b"project notices".to_vec(),
+            ),
+            (
+                "licenses/project/THIRD_PARTY_NOTICES.md".to_string(),
+                b"tool notices".to_vec(),
+            ),
+            (
+                "licenses/project/NOTICE".to_string(),
+                b"third party notice".to_vec(),
+            ),
         ];
         let manifest = entries
             .iter()
@@ -781,6 +1284,107 @@ mod tests {
             writer.write_all(bytes).unwrap();
         }
         writer.finish().unwrap();
+    }
+
+    fn macos_package_entries() -> Vec<(String, Vec<u8>, u32)> {
+        let mut entries = vec![
+            ("grok-zh".to_string(), b"verified Mach-O".to_vec(), 0o755),
+            (
+                "BUILD-INFO.txt".to_string(),
+                b"unsigned macOS ARM64 build".to_vec(),
+                0o644,
+            ),
+            (
+                "INSTALL-MACOS.md".to_string(),
+                b"installation guide".to_vec(),
+                0o644,
+            ),
+            (
+                "Install-GrokZh.sh".to_string(),
+                b"#!/bin/sh\nexit 0\n".to_vec(),
+                0o755,
+            ),
+            (
+                "LICENSE-grok-build.txt".to_string(),
+                b"license".to_vec(),
+                0o644,
+            ),
+            (
+                "NOTICE-third-party.txt".to_string(),
+                b"notice".to_vec(),
+                0o644,
+            ),
+            ("SOURCE_REV".to_string(), b"deadbeef".to_vec(), 0o644),
+            (
+                "THIRD-PARTY-NOTICES.txt".to_string(),
+                b"third party".to_vec(),
+                0o644,
+            ),
+            (
+                "THIRD-PARTY-NOTICES-xai-grok-tools.md".to_string(),
+                b"tools notices".to_vec(),
+                0o644,
+            ),
+        ];
+        let manifest = entries
+            .iter()
+            .map(|(name, bytes, _)| format!("{}  {name}", sha256_hex(bytes)))
+            .collect::<Vec<_>>()
+            .join("\n");
+        entries.push((INNER_MANIFEST.to_string(), manifest.into_bytes(), 0o644));
+        entries
+    }
+
+    fn append_ustar_entry<W: Write>(
+        builder: &mut tar::Builder<W>,
+        name: &str,
+        bytes: &[u8],
+        mode: u32,
+        entry_type: tar::EntryType,
+        link_name: Option<&str>,
+    ) {
+        let mut header = tar::Header::new_ustar();
+        header.set_entry_type(entry_type);
+        header.set_mode(mode);
+        header.set_size(bytes.len() as u64);
+        if let Some(link_name) = link_name {
+            header.set_link_name(link_name).unwrap();
+        }
+        header.set_cksum();
+        builder.append_data(&mut header, name, bytes).unwrap();
+    }
+
+    fn write_macos_tar(
+        path: &Path,
+        entries: &[(String, Vec<u8>, u32)],
+        extra: Option<(&str, tar::EntryType, Option<&str>)>,
+    ) {
+        let file = File::create(path).unwrap();
+        let encoder = flate2::write::GzEncoder::new(file, flate2::Compression::default());
+        let mut builder = tar::Builder::new(encoder);
+        append_ustar_entry(
+            &mut builder,
+            ".",
+            &[],
+            0o755,
+            tar::EntryType::Directory,
+            None,
+        );
+        for (name, bytes, mode) in entries {
+            append_ustar_entry(
+                &mut builder,
+                name,
+                bytes,
+                *mode,
+                tar::EntryType::Regular,
+                None,
+            );
+        }
+        if let Some((name, entry_type, link_name)) = extra {
+            append_ustar_entry(&mut builder, name, &[], 0o644, entry_type, link_name);
+        }
+        let encoder = builder.into_inner().unwrap();
+        encoder.finish().unwrap();
     }
 
     #[test]
@@ -845,24 +1449,88 @@ mod tests {
     }
 
     #[test]
-    #[cfg(all(target_os = "windows", target_arch = "x86_64", target_env = "gnu"))]
-    fn asset_selection_requires_the_exact_zip_only_asset_set() {
-        let mut candidate = release("v1.2.3", false, true);
-        candidate.assets = uploaded_package_assets("1.2.3");
-        let selected = select_asset(&candidate, "1.2.3").unwrap();
-        assert_eq!(selected.version, "1.2.3");
-        assert_eq!(selected.name, "grok-zh-1.2.3-windows-x86_64-gnu.zip");
+    fn asset_selection_enforces_the_two_stage_exact_asset_contract() {
+        let mut transition = release("v1.0.6", false, true);
+        transition.assets = uploaded_package_assets("1.0.6");
+        let selected =
+            select_asset_for_platform(&transition, "1.0.6", CommunityPlatform::WindowsX86_64Gnu)
+                .unwrap();
+        assert_eq!(selected.version, "1.0.6");
+        assert_eq!(selected.name, "grok-zh-1.0.6-windows-x86_64-gnu.zip");
+        assert!(
+            select_asset_for_platform(&transition, "1.0.6", CommunityPlatform::MacosAarch64)
+                .is_err()
+        );
+
+        let mut candidate = release("v1.0.7-alpha.1", true, true);
+        candidate.assets = uploaded_package_assets("1.0.7-alpha.1");
+        let windows = select_asset_for_platform(
+            &candidate,
+            "1.0.7-alpha.1",
+            CommunityPlatform::WindowsX86_64Gnu,
+        )
+        .unwrap();
+        assert_eq!(windows.name, "grok-zh-1.0.7-alpha.1-windows-x86_64-gnu.zip");
+        let macos =
+            select_asset_for_platform(&candidate, "1.0.7-alpha.1", CommunityPlatform::MacosAarch64)
+                .unwrap();
+        assert_eq!(macos.name, "grok-zh-1.0.7-alpha.1-macos-aarch64.tar.gz");
 
         candidate.assets.push(uploaded_asset(
-            "1.2.3",
-            "grok-zh-1.2.3-windows-x86_64-gnu.exe".to_string(),
+            "1.0.7-alpha.1",
+            "grok-zh-1.0.7-alpha.1-windows-x86_64-gnu.exe".to_string(),
             123,
         ));
-        assert!(select_asset(&candidate, "1.2.3").is_err());
+        assert!(
+            select_asset_for_platform(
+                &candidate,
+                "1.0.7-alpha.1",
+                CommunityPlatform::WindowsX86_64Gnu
+            )
+            .is_err()
+        );
 
         candidate.assets.pop();
         candidate.assets[0].browser_download_url = "https://example.com/grok-zh.zip".to_string();
-        assert!(select_asset(&candidate, "1.2.3").is_err());
+        assert!(
+            select_asset_for_platform(
+                &candidate,
+                "1.0.7-alpha.1",
+                CommunityPlatform::WindowsX86_64Gnu
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn latest_release_selection_skips_platform_incompatible_assets() {
+        let mut transition = release("v1.0.6", false, true);
+        transition.assets = uploaded_package_assets("1.0.6");
+        let mut cross_platform = release("v1.0.7", false, true);
+        cross_platform.assets = uploaded_package_assets("1.0.7");
+        let releases = vec![cross_platform, transition];
+
+        let (_, windows) = select_latest_compatible_release(
+            &releases,
+            "stable",
+            CommunityPlatform::WindowsX86_64Gnu,
+        )
+        .unwrap();
+        assert_eq!(windows.to_string(), "1.0.7");
+        let (_, macos) =
+            select_latest_compatible_release(&releases, "stable", CommunityPlatform::MacosAarch64)
+                .unwrap();
+        assert_eq!(macos.to_string(), "1.0.7");
+
+        let only_transition = &releases[1..];
+        assert!(
+            select_latest_compatible_release(
+                only_transition,
+                "stable",
+                CommunityPlatform::MacosAarch64
+            )
+            .is_err()
+        );
     }
 
     #[test]
@@ -938,7 +1606,7 @@ mod tests {
         let candidate = temp.path().join("candidate.exe");
         write_zip(&archive, &package_entries());
 
-        extract_verified_executable(&archive, &candidate).unwrap();
+        extract_verified_windows_executable(&archive, &candidate).unwrap();
         assert_eq!(std::fs::read(candidate).unwrap(), b"verified executable");
         assert!(!temp.path().join("rg.exe").exists());
     }
@@ -956,7 +1624,7 @@ mod tests {
             .1 = b"tampered executable".to_vec();
         write_zip(&archive, &entries);
 
-        let error = extract_verified_executable(&archive, &candidate).unwrap_err();
+        let error = extract_verified_windows_executable(&archive, &candidate).unwrap_err();
         assert!(error.to_string().contains("inner SHA-256 mismatch"));
         assert!(!candidate.exists());
     }
@@ -970,29 +1638,29 @@ mod tests {
         let mut entries = package_entries();
         entries.push(("../escape.txt".to_string(), b"escape".to_vec()));
         write_zip(&traversal, &entries);
-        assert!(extract_verified_executable(&traversal, &candidate).is_err());
+        assert!(extract_verified_windows_executable(&traversal, &candidate).is_err());
         assert!(!candidate.exists());
 
         let internal_parent = temp.path().join("internal-parent.zip");
         let mut entries = package_entries();
         entries.push(("nested/../escape.txt".to_string(), b"escape".to_vec()));
         write_zip(&internal_parent, &entries);
-        assert!(extract_verified_executable(&internal_parent, &candidate).is_err());
+        assert!(extract_verified_windows_executable(&internal_parent, &candidate).is_err());
         assert!(!candidate.exists());
 
         let current_segment = temp.path().join("current-segment.zip");
         let mut entries = package_entries();
         entries.push(("./escape.txt".to_string(), b"escape".to_vec()));
         write_zip(&current_segment, &entries);
-        assert!(extract_verified_executable(&current_segment, &candidate).is_err());
+        assert!(extract_verified_windows_executable(&current_segment, &candidate).is_err());
         assert!(!candidate.exists());
 
         let duplicate_normalized_entry = temp.path().join("duplicate-normalized-entry.zip");
         let mut entries = package_entries();
         entries.push(("RG.EXE".to_string(), b"duplicate ripgrep".to_vec()));
         write_zip(&duplicate_normalized_entry, &entries);
-        let error =
-            extract_verified_executable(&duplicate_normalized_entry, &candidate).unwrap_err();
+        let error = extract_verified_windows_executable(&duplicate_normalized_entry, &candidate)
+            .unwrap_err();
         assert!(error.to_string().contains("duplicate path"), "{error:#}");
         assert!(!candidate.exists());
 
@@ -1000,7 +1668,7 @@ mod tests {
         let mut entries = package_entries();
         entries.push(("É.txt".to_string(), b"ambiguous on Windows".to_vec()));
         write_zip(&non_ascii_entry, &entries);
-        assert!(extract_verified_executable(&non_ascii_entry, &candidate).is_err());
+        assert!(extract_verified_windows_executable(&non_ascii_entry, &candidate).is_err());
         assert!(!candidate.exists());
 
         let non_ascii_manifest = temp.path().join("non-ascii-manifest.zip");
@@ -1013,7 +1681,7 @@ mod tests {
             .1
             .extend_from_slice(format!("\n{}  É.txt", "00".repeat(32)).as_bytes());
         write_zip(&non_ascii_manifest, &entries);
-        assert!(extract_verified_executable(&non_ascii_manifest, &candidate).is_err());
+        assert!(extract_verified_windows_executable(&non_ascii_manifest, &candidate).is_err());
         assert!(!candidate.exists());
 
         let duplicate_unicode_manifest = temp.path().join("duplicate-unicode-manifest.zip");
@@ -1026,7 +1694,9 @@ mod tests {
             .1
             .extend_from_slice(format!("\n{}  {ONE_CLICK_INSTALLER}", "00".repeat(32)).as_bytes());
         write_zip(&duplicate_unicode_manifest, &entries);
-        assert!(extract_verified_executable(&duplicate_unicode_manifest, &candidate).is_err());
+        assert!(
+            extract_verified_windows_executable(&duplicate_unicode_manifest, &candidate).is_err()
+        );
         assert!(!candidate.exists());
 
         for (suffix, missing_required) in [
@@ -1048,8 +1718,138 @@ mod tests {
                 .join("\n")
                 .into_bytes();
             write_zip(&incomplete, &entries);
-            assert!(extract_verified_executable(&incomplete, &candidate).is_err());
+            assert!(extract_verified_windows_executable(&incomplete, &candidate).is_err());
             assert!(!candidate.exists());
         }
+    }
+
+    #[test]
+    fn valid_macos_tar_extracts_only_the_verified_executable() {
+        let temp = tempfile::tempdir().unwrap();
+        let archive = temp.path().join("release.tar.gz");
+        let candidate = temp.path().join("candidate");
+        write_macos_tar(&archive, &macos_package_entries(), None);
+
+        extract_verified_macos_executable(&archive, &candidate).unwrap();
+        assert_eq!(std::fs::read(candidate).unwrap(), b"verified Mach-O");
+        assert!(!temp.path().join("BUILD-INFO.txt").exists());
+    }
+
+    #[test]
+    fn macos_tar_hash_mismatch_fails_closed_and_removes_candidate() {
+        let temp = tempfile::tempdir().unwrap();
+        let archive = temp.path().join("release.tar.gz");
+        let candidate = temp.path().join("candidate");
+        let mut entries = macos_package_entries();
+        entries
+            .iter_mut()
+            .find(|(name, _, _)| name == "grok-zh")
+            .unwrap()
+            .1 = b"tampered Mach-O".to_vec();
+        write_macos_tar(&archive, &entries, None);
+
+        let error = extract_verified_macos_executable(&archive, &candidate).unwrap_err();
+        assert!(error.to_string().contains("inner SHA-256 mismatch"));
+        assert!(!candidate.exists());
+    }
+
+    #[test]
+    fn macos_tar_rejects_extra_duplicate_and_link_entries() {
+        let temp = tempfile::tempdir().unwrap();
+        let candidate = temp.path().join("candidate");
+        let entries = macos_package_entries();
+
+        for (suffix, extra) in [
+            ("extra", ("extra.txt", tar::EntryType::Regular, None)),
+            ("duplicate", ("GROK-ZH", tar::EntryType::Regular, None)),
+            (
+                "symlink",
+                ("replacement", tar::EntryType::Symlink, Some("grok-zh")),
+            ),
+            (
+                "hardlink",
+                ("replacement", tar::EntryType::Link, Some("grok-zh")),
+            ),
+        ] {
+            let archive = temp.path().join(format!("{suffix}.tar.gz"));
+            write_macos_tar(&archive, &entries, Some(extra));
+            assert!(
+                extract_verified_macos_executable(&archive, &candidate).is_err(),
+                "{suffix} tar should be rejected"
+            );
+            assert!(!candidate.exists());
+        }
+    }
+
+    #[test]
+    fn macos_tar_rejects_trailing_gzip_payload() {
+        let temp = tempfile::tempdir().unwrap();
+        let archive = temp.path().join("release.tar.gz");
+        let candidate = temp.path().join("candidate");
+        write_macos_tar(&archive, &macos_package_entries(), None);
+
+        let mut trailing_encoder =
+            flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+        trailing_encoder
+            .write_all(b"unexpected trailing member")
+            .unwrap();
+        let trailing = trailing_encoder.finish().unwrap();
+        let mut archive_file = OpenOptions::new().append(true).open(&archive).unwrap();
+        archive_file.write_all(&trailing).unwrap();
+        archive_file.sync_all().unwrap();
+
+        assert!(extract_verified_macos_executable(&archive, &candidate).is_err());
+        assert!(!candidate.exists());
+
+        for (suffix, trailing_bytes) in [("empty", Vec::new()), ("zeros", vec![0u8; 512])] {
+            let archive = temp.path().join(format!("release-{suffix}.tar.gz"));
+            write_macos_tar(&archive, &macos_package_entries(), None);
+            let mut encoder =
+                flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+            encoder.write_all(&trailing_bytes).unwrap();
+            let trailing = encoder.finish().unwrap();
+            let mut archive_file = OpenOptions::new().append(true).open(&archive).unwrap();
+            archive_file.write_all(&trailing).unwrap();
+            archive_file.sync_all().unwrap();
+
+            assert!(
+                extract_verified_macos_executable(&archive, &candidate).is_err(),
+                "concatenated {suffix} gzip member must be rejected"
+            );
+            assert!(!candidate.exists());
+        }
+    }
+
+    #[test]
+    fn macos_tar_requires_root_entry_modes_and_complete_end_marker() {
+        let temp = tempfile::tempdir().unwrap();
+        let candidate = temp.path().join("candidate");
+
+        let wrong_mode = temp.path().join("wrong-mode.tar.gz");
+        let mut entries = macos_package_entries();
+        entries
+            .iter_mut()
+            .find(|(name, _, _)| name == "Install-GrokZh.sh")
+            .unwrap()
+            .2 = 0o644;
+        write_macos_tar(&wrong_mode, &entries, None);
+        assert!(extract_verified_macos_executable(&wrong_mode, &candidate).is_err());
+        assert!(!candidate.exists());
+
+        let valid = temp.path().join("valid.tar.gz");
+        write_macos_tar(&valid, &macos_package_entries(), None);
+        let mut decoder = flate2::read::GzDecoder::new(File::open(&valid).unwrap());
+        let mut raw_tar = Vec::new();
+        decoder.read_to_end(&mut raw_tar).unwrap();
+        let last_nonzero = raw_tar.iter().rposition(|byte| *byte != 0).unwrap();
+        let truncated_len = (last_nonzero + 512) / 512 * 512;
+        raw_tar.truncate(truncated_len);
+        let truncated = temp.path().join("missing-end-marker.tar.gz");
+        let file = File::create(&truncated).unwrap();
+        let mut encoder = flate2::write::GzEncoder::new(file, flate2::Compression::default());
+        encoder.write_all(&raw_tar).unwrap();
+        encoder.finish().unwrap();
+        assert!(extract_verified_macos_executable(&truncated, &candidate).is_err());
+        assert!(!candidate.exists());
     }
 }

--- a/crates/codegen/xai-grok-update/src/lib.rs
+++ b/crates/codegen/xai-grok-update/src/lib.rs
@@ -218,11 +218,11 @@ pub const fn official_update_sources_allowed() -> bool {
 pub const fn community_updates_enabled() -> bool {
     cfg!(feature = "community-build")
         && xai_grok_product::AUTO_UPDATE_ENABLED
-        && cfg!(all(
+        && (cfg!(all(
             target_os = "windows",
             target_arch = "x86_64",
             target_env = "gnu"
-        ))
+        )) || cfg!(all(target_os = "macos", target_arch = "aarch64")))
 }
 
 pub(crate) fn ensure_updates_enabled() -> anyhow::Result<()> {
@@ -273,7 +273,7 @@ mod community_build_tests {
             target_os = "windows",
             target_arch = "x86_64",
             target_env = "gnu"
-        ));
+        )) || cfg!(all(target_os = "macos", target_arch = "aarch64"));
         assert_eq!(updates_enabled(), supported_target);
         assert!(!default_auto_update_enabled());
         assert_eq!(community_updates_enabled(), supported_target);

--- a/crates/codegen/xai-grok-update/src/version.rs
+++ b/crates/codegen/xai-grok-update/src/version.rs
@@ -503,7 +503,7 @@ pub fn installed_on_disk_version() -> Option<String> {
     #[cfg(unix)]
     {
         let app = if cfg!(feature = "community-build") {
-            xai_grok_shell::util::grok_home::resolve_grok_home()?
+            xai_grok_home::resolve_grok_home()?
                 .join("bin")
                 .join(xai_grok_product::CLI_NAME)
         } else {

--- a/crates/codegen/xai-grok-update/src/version.rs
+++ b/crates/codegen/xai-grok-update/src/version.rs
@@ -502,8 +502,28 @@ pub use xai_grok_version::installed as get_installed_grok_version;
 pub fn installed_on_disk_version() -> Option<String> {
     #[cfg(unix)]
     {
-        let app = xai_grok_shell::util::grok_home::grok_application();
+        let app = if cfg!(feature = "community-build") {
+            xai_grok_shell::util::grok_home::resolve_grok_home()?
+                .join("bin")
+                .join(xai_grok_product::CLI_NAME)
+        } else {
+            xai_grok_shell::util::grok_home::grok_application()
+        };
         let target = std::fs::read_link(&app).ok()?;
+        if cfg!(feature = "community-build") {
+            if target.is_absolute()
+                || target.parent()? != std::path::Path::new("../grok-zh-downloads")
+            {
+                return None;
+            }
+            let resolved = app.parent()?.join(&target);
+            let metadata = std::fs::symlink_metadata(resolved).ok()?;
+            if metadata.file_type().is_symlink() || !metadata.is_file() {
+                return None;
+            }
+            return version_from_community_macos_binary_name(target.file_name()?.to_str()?);
+        }
+
         // metadata() follows the symlink: Err means the target is gone
         // (dangling link) and the version it names is not actually on disk.
         std::fs::metadata(&app).ok()?;
@@ -521,23 +541,51 @@ pub fn installed_on_disk_version() -> Option<String> {
 /// pre-releases: `grok-0.1.150-alpha.1-linux-x86_64` → `0.1.150-alpha.1`)
 /// and the npm layout without a platform suffix (`grok-0.1.150`,
 /// `grok-0.1.150-alpha.1`): everything between the `{bin_prefix}-` prefix
-/// and the first platform-OS component is the version, validated as semver
+/// and a recognized platform suffix is the version, validated as semver
 /// so unknown layouts (`grok-latest`, `grok-pager-*` when `bin_prefix` is
 /// `grok`) return `None` instead of garbage.
 ///
 /// Shared by the disk-version probe above and `cleanup_old_downloads` in
 /// `auto_update` — keep it the single place that understands this naming.
 pub(crate) fn version_from_versioned_binary_name(name: &str, bin_prefix: &str) -> Option<String> {
-    const PLATFORM_OS: &[&str] = &["macos", "linux", "darwin", "windows"];
     let suffix = name.strip_prefix(bin_prefix)?.strip_prefix('-')?;
-    let parts: Vec<&str> = suffix.split('-').collect();
-    let platform_start = parts
+    const PLATFORM_SUFFIXES: &[&str] = &[
+        "-macos-aarch64",
+        "-macos-x86_64",
+        "-darwin-arm64",
+        "-darwin-aarch64",
+        "-darwin-x86_64",
+        "-linux-aarch64",
+        "-linux-x86_64",
+        "-windows-aarch64.exe",
+        "-windows-x86_64.exe",
+        "-windows-aarch64",
+        "-windows-x86_64",
+    ];
+    let version = PLATFORM_SUFFIXES
         .iter()
-        .position(|p| PLATFORM_OS.contains(p))
-        .unwrap_or(parts.len());
-    let ver_str = parts[..platform_start].join("-");
-    Version::parse(&ver_str).ok()?;
-    Some(ver_str)
+        .find_map(|platform| suffix.strip_suffix(platform))
+        .unwrap_or(suffix);
+    Version::parse(version).ok()?;
+    Some(version.to_string())
+}
+
+pub(crate) fn version_from_community_macos_binary_name(name: &str) -> Option<String> {
+    let suffix = name.strip_prefix("grok-zh-")?;
+    let (version, nonce) = suffix.rsplit_once("-macos-aarch64.")?;
+    let nonce = nonce.strip_suffix(".installed")?;
+    if nonce.is_empty()
+        || !nonce
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || byte == b'-')
+    {
+        return None;
+    }
+    let parsed = Version::parse(version).ok()?;
+    if !parsed.build.is_empty() || parsed.to_string() != version {
+        return None;
+    }
+    Some(version.to_string())
 }
 
 /// Fetch the stable channel pointer for caching alongside the version.
@@ -695,6 +743,8 @@ mod tests {
             // would make an alpha install masquerade as the release and
             // mask alpha → stable updates.
             ("grok-0.1.220-alpha.4-linux-x86_64", Some("0.1.220-alpha.4")),
+            ("grok-1.0.7-linux-macos-aarch64", Some("1.0.7-linux")),
+            ("grok-1.0.7-macos-macos-aarch64", Some("1.0.7-macos")),
             ("grok-0.1.220-alpha.4", Some("0.1.220-alpha.4")), // npm layout
             ("grok-pager-0.1.5-darwin-arm64", None),           // "pager" is not a version
             ("grok-garbage-darwin-arm64", None),               // unparseable version
@@ -719,6 +769,28 @@ mod tests {
                 .as_deref(),
             Some("0.1.5")
         );
+
+        assert_eq!(
+            version_from_community_macos_binary_name("grok-zh-1.0.7-macos-aarch64.42-0.installed")
+                .as_deref(),
+            Some("1.0.7")
+        );
+        assert_eq!(
+            version_from_community_macos_binary_name(
+                "grok-zh-1.0.8-linux.macos-alpha.2-macos-aarch64.7-3.installed"
+            )
+            .as_deref(),
+            Some("1.0.8-linux.macos-alpha.2")
+        );
+        for invalid in [
+            "grok-zh-1.0.7",
+            "grok-zh-1.0.7-macos-aarch64.installed",
+            "grok-zh-1.0.7-macos-aarch64.bad/name.installed",
+            "grok-zh-1.0.7-macos-aarch64.42-0.candidate",
+            "grok-zh-1.0.7+local-macos-aarch64.42-0.installed",
+        ] {
+            assert_eq!(version_from_community_macos_binary_name(invalid), None);
+        }
     }
 
     // ──────────────────────────────────────────────────────────────────────

--- a/packaging/macos/INSTALL-MACOS.md
+++ b/packaging/macos/INSTALL-MACOS.md
@@ -1,31 +1,62 @@
-# macOS ARM64 预览版
+# macOS ARM64 安装说明
 
-此软件包是 Grok Build 简体中文社区版的 Apple Silicon 预览构建，仅支持
+此软件包是 Grok Build 简体中文社区版的 Apple Silicon 构建，仅支持
 `aarch64-apple-darwin`（M1 及后续 Apple Silicon）。它不是 SpaceXAI 官方发行版。
 
 ## 安全边界
 
-- 预览包由 GitHub Actions 的 `macos-15` Apple Silicon runner 构建，并在 CI 中执行
-  `grok-zh --version` 冒烟测试。
-- 软件包提供外层 `.sha256` 和包内 `SHA256SUMS.txt`，但尚未使用 Apple Developer ID
-  签名，也没有经过 Apple 公证。
-- 未签名预览包可能被 macOS Gatekeeper 阻止。请勿关闭系统安全功能；正式使用前请等待
-  本仓库完成签名、公证与真实设备验收。
-- 默认继续与官方 `grok` 共用 `~/.grok` 数据目录，不会复制聊天记录、登录状态或配置。
+- 软件包由 GitHub Actions 的 `macos-15` Apple Silicon runner 构建，并在 CI 中检查
+  纯 ARM64 Mach-O 架构、包内文件、二次安装、入口链接和 `grok-zh --version`。
+- 正式 Release 同时提供外层 `.sha256`，包内提供严格的 `SHA256SUMS.txt`。内置更新器
+  只接受本仓库中不可变、资产集合完整且 GitHub SHA-256 元数据匹配的 Release。
+- 当前构建未使用 Apple Developer ID 签名，也没有经过 Apple 公证。首次运行仍可能被
+  Gatekeeper 阻止；安装器不会关闭 Gatekeeper、移除 quarantine 属性或修改系统安全设置。
+- 默认与官方 `grok` 共用 `~/.grok` 数据目录，但程序入口与下载目录保持独立。
 
-## 校验与试运行
+## 校验并安装
 
-把 `.tar.gz` 和同名 `.sha256` 放在同一目录，然后运行：
+把 `.tar.gz` 和同名 `.sha256` 放在同一目录，把下面的版本替换为实际下载版本后再校验并解包：
 
 ```sh
-shasum -a 256 -c grok-zh-*-macos-aarch64.tar.gz.sha256
-mkdir grok-zh-macos-preview
-tar -xzf grok-zh-*-macos-aarch64.tar.gz -C grok-zh-macos-preview
-cd grok-zh-macos-preview
+archive='grok-zh-1.0.7-macos-aarch64.tar.gz'
+test -f "$archive" && test -f "$archive.sha256"
+shasum -a 256 -c "$archive.sha256"
+mkdir grok-zh-macos
+tar -xzf "$archive" -C grok-zh-macos
+cd grok-zh-macos
 shasum -a 256 -c SHA256SUMS.txt
 ./grok-zh --version
+./Install-GrokZh.sh
 ```
 
-当前包只用于预览测试，不会安装全局命令，也不会覆盖官方 `grok`。正式 Release 与
-macOS 社区自动更新将由本仓库的统一发布流程提供，不能用 Actions Artifact 代替正式
-Release 验收。
+默认只在 `${GROK_HOME:-$HOME/.grok}/bin` 建立 `grok-zh`、`agent-zh` 两个入口，
+不会修改 `.zshrc`、`.bashrc`、`/usr/local/bin` 或官方命令。若你明确希望在同一用户目录
+中使用 `grok`、`agent` 兼容入口，可以运行：
+
+```sh
+./Install-GrokZh.sh --with-compat-aliases
+```
+
+完成外层校验后，安装器会验证精确的包内文件集合、内层清单、版本、架构和目标目录，
+再把程序复制到新的不可变版本文件，最后
+原子切换入口链接。在没有同用户并发篡改的情况下，已有普通文件或不属于本安装器的链接不会被覆盖。
+安装完成后按提示把 `${GROK_HOME:-$HOME/.grok}/bin` 加入 `PATH`，重新打开终端并运行 `grok-zh`；启用兼容入口的用户也可以
+运行 `grok`。
+
+## 自动更新
+
+- `grok-zh update` 和 TUI 更新入口只读取本仓库 Releases；不会访问官方 npm、x.ai、
+  GCS 或官方 GitHub Release。
+- macOS 更新不会覆盖当前进程正在使用的 Mach-O 文件。每次安装都会保留新的版本目标，
+  校验并冒烟运行后，再原子切换 `grok-zh` 与 `agent-zh`。旧目标不会自动删除，以免仍在
+  运行的进程丢失可执行文件。
+- 后台自动下载默认关闭；用户可在设置中显式开启，或手动确认单次更新。
+- 自动更新不等于 Apple 签名或公证。没有 Apple Developer ID 时仍能构建、校验、安装和
+  更新，但 Gatekeeper 的首次运行提示不会因此消失。
+
+Actions Artifact 只用于预览测试，不是正式更新源。正式自动更新只消费本仓库统一发布
+工作流生成的 Immutable GitHub Release。
+
+自定义 `GROK_HOME` 必须是绝对、非根路径；其父目录必须已存在，现有路径组件
+不能是符号链接，只允许最终的 `GROK_HOME` 目录由安装器或更新器创建。安装器
+另外拒绝含冒号的路径，避免生成含多个目录项的 `PATH`。这是防目录劫持的安全边界。

--- a/packaging/macos/Install-GrokZh.sh
+++ b/packaging/macos/Install-GrokZh.sh
@@ -1,0 +1,347 @@
+#!/bin/sh
+
+set -eu
+
+# Do not trust a caller-controlled PATH for integrity and architecture checks.
+CALLER_PATH=${PATH-}
+PATH=/usr/bin:/bin:/usr/sbin:/sbin
+export PATH
+
+PROGRAM_NAME=Install-GrokZh.sh
+WITH_COMPAT_ALIASES=0
+STAGE_FILE=
+LINK_SEQ=0
+
+die() {
+  printf '%s\n' "${PROGRAM_NAME}: $*" >&2
+  exit 1
+}
+
+usage() {
+  cat <<'EOF'
+用法：./Install-GrokZh.sh [--with-compat-aliases]
+
+默认只安装 grok-zh 和 agent-zh。指定 --with-compat-aliases 后，还会在
+同一个 ~/.grok/bin 目录中创建 grok -> grok-zh 和 agent -> agent-zh；
+安装器不会修改 shell 配置，也不会写入 /usr/local/bin。
+EOF
+}
+
+for arg in "$@"; do
+  case "$arg" in
+    --with-compat-aliases) WITH_COMPAT_ALIASES=1 ;;
+    -h|--help) usage; exit 0 ;;
+    *) die "未知参数：$arg" ;;
+  esac
+done
+
+umask 077
+
+[ "$(uname -s)" = Darwin ] || die "此安装器只支持 macOS。"
+[ "$(uname -m)" = arm64 ] || die "此安装器只支持 Apple Silicon（arm64）。"
+[ ! -L "$0" ] || die "请直接运行软件包中的安装器，不要通过符号链接启动。"
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname "$0")" && pwd -P) || die "无法定位软件包目录。"
+case "$SCRIPT_DIR" in
+  *'
+'*) die "软件包目录不能包含换行符。" ;;
+esac
+
+MANIFEST="$SCRIPT_DIR/SHA256SUMS.txt"
+[ -f "$MANIFEST" ] && [ ! -L "$MANIFEST" ] || die "缺少可信的 SHA256SUMS.txt。"
+
+EXPECTED_NAMES='BUILD-INFO.txt
+INSTALL-MACOS.md
+Install-GrokZh.sh
+LICENSE-grok-build.txt
+NOTICE-third-party.txt
+SOURCE_REV
+THIRD-PARTY-NOTICES-xai-grok-tools.md
+THIRD-PARTY-NOTICES.txt
+grok-zh'
+
+seen_names=
+manifest_count=0
+while IFS= read -r manifest_line || [ -n "$manifest_line" ]; do
+  hash=${manifest_line%%  *}
+  name=${manifest_line#*  }
+  [ "$hash" != "$manifest_line" ] || die "SHA256SUMS.txt 格式无效。"
+  [ ${#hash} -eq 64 ] || die "SHA256SUMS.txt 包含无效 SHA-256。"
+  printf '%s\n' "$hash" | grep -Eq '^[0-9a-f]{64}$' || die "SHA256SUMS.txt 包含无效 SHA-256。"
+  printf '%s\n' "$EXPECTED_NAMES" | grep -Fx -- "$name" >/dev/null || die "SHA256SUMS.txt 包含未批准文件：$name"
+  case "
+$seen_names
+" in
+    *"
+$name
+"*) die "SHA256SUMS.txt 包含重复文件：$name" ;;
+  esac
+  [ -f "$SCRIPT_DIR/$name" ] && [ ! -L "$SCRIPT_DIR/$name" ] || die "软件包文件缺失或不是普通文件：$name"
+  seen_names="${seen_names}${seen_names:+
+}$name"
+  manifest_count=$((manifest_count + 1))
+done < "$MANIFEST"
+
+[ "$manifest_count" -eq 9 ] || die "SHA256SUMS.txt 未覆盖完整软件包。"
+for expected_name in $EXPECTED_NAMES; do
+  case "
+$seen_names
+" in
+    *"
+$expected_name
+"*) ;;
+    *) die "SHA256SUMS.txt 缺少文件：$expected_name" ;;
+  esac
+done
+
+package_entry_count=$(find "$SCRIPT_DIR" -mindepth 1 -maxdepth 1 -print | wc -l | tr -d '[:space:]')
+regular_file_count=$(find "$SCRIPT_DIR" -mindepth 1 -maxdepth 1 -type f ! -type l -print | wc -l | tr -d '[:space:]')
+[ "$package_entry_count" -eq 10 ] && [ "$regular_file_count" -eq 10 ] || \
+  die "软件包根目录必须恰好包含 10 个已批准的普通文件。"
+
+(cd "$SCRIPT_DIR" && shasum -a 256 -c SHA256SUMS.txt) || die "软件包 SHA-256 校验失败。"
+file_output=$(file -b "$SCRIPT_DIR/grok-zh") || die "无法检查 grok-zh 文件类型。"
+printf '%s\n' "$file_output" | grep -Eq 'Mach-O .*executable arm64' || die "grok-zh 不是 ARM64 Mach-O 可执行文件。"
+binary_archs=$(lipo -archs "$SCRIPT_DIR/grok-zh") || die "无法检查 grok-zh 架构。"
+[ "$binary_archs" = arm64 ] || die "grok-zh 必须是纯 ARM64 Mach-O，实际架构：$binary_archs"
+
+version_output=$("$SCRIPT_DIR/grok-zh" --version 2>/dev/null) || die "软件包中的 grok-zh 无法运行。"
+version_line=$(printf '%s\n' "$version_output" | sed -n '1p')
+version=$(printf '%s\n' "$version_line" | sed -E -n 's/^grok-zh ([0-9A-Za-z.+-]+) \(.*/\1/p')
+[ -n "$version" ] || die "无法从 grok-zh --version 读取版本。"
+[ ${#version} -le 64 ] || die "软件包版本过长。"
+semver_body='(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*)(\.(0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*))*))?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?'
+semver_pattern="^${semver_body}$"
+printf '%s\n' "$version" | grep -Eq "$semver_pattern" || die "软件包版本不是严格 SemVer：$version"
+
+: "${HOME:?HOME 未设置}"
+GROK_HOME_DIR=${GROK_HOME:-"$HOME/.grok"}
+while [ "$GROK_HOME_DIR" != / ] && [ "${GROK_HOME_DIR%/}" != "$GROK_HOME_DIR" ]; do
+  GROK_HOME_DIR=${GROK_HOME_DIR%/}
+done
+case "$GROK_HOME_DIR" in
+  /*) ;;
+  *) die "GROK_HOME 必须是绝对路径。" ;;
+esac
+case "$GROK_HOME_DIR/" in
+  *'/../'*|*'/./'*|*'//'*|*:*|*'
+'*) die "GROK_HOME 包含不安全的路径组件。" ;;
+esac
+[ "$GROK_HOME_DIR" != / ] || die "拒绝把根目录用作 GROK_HOME。"
+
+GROK_HOME_PARENT=$(dirname "$GROK_HOME_DIR") || die "无法解析 GROK_HOME 父目录。"
+[ -d "$GROK_HOME_PARENT" ] && [ ! -L "$GROK_HOME_PARENT" ] || \
+  die "GROK_HOME 父目录必须预先存在且不能是符号链接：$GROK_HOME_PARENT"
+physical_parent=$(CDPATH= cd -- "$GROK_HOME_PARENT" && pwd -P) || die "无法解析 GROK_HOME 父目录。"
+[ "$physical_parent" = "$GROK_HOME_PARENT" ] || \
+  die "GROK_HOME 父目录路径中包含符号链接：$GROK_HOME_PARENT"
+
+ensure_secure_dir() {
+  secure_dir=$1
+  [ ! -L "$secure_dir" ] || die "拒绝使用符号链接目录：$secure_dir"
+  if [ -e "$secure_dir" ]; then
+    [ -d "$secure_dir" ] || die "安装路径不是目录：$secure_dir"
+  else
+    mkdir -m 700 "$secure_dir" || die "无法创建目录：$secure_dir"
+  fi
+  [ ! -L "$secure_dir" ] && [ -d "$secure_dir" ] || die "安装目录在创建时发生变化：$secure_dir"
+  physical_dir=$(CDPATH= cd -- "$secure_dir" && pwd -P) || die "无法解析目录：$secure_dir"
+  [ "$physical_dir" = "$secure_dir" ] || die "安装目录路径中包含符号链接：$secure_dir"
+  [ "$(stat -f '%u' "$secure_dir")" = "$(id -u)" ] || die "安装目录不属于当前用户：$secure_dir"
+  chmod 700 "$secure_dir" || die "无法保护目录权限：$secure_dir"
+  [ "$(stat -f '%Lp' "$secure_dir")" = 700 ] || die "安装目录权限不是 0700：$secure_dir"
+}
+
+BIN_DIR="$GROK_HOME_DIR/bin"
+DOWNLOAD_DIR="$GROK_HOME_DIR/grok-zh-downloads"
+ensure_secure_dir "$GROK_HOME_DIR"
+ensure_secure_dir "$BIN_DIR"
+ensure_secure_dir "$DOWNLOAD_DIR"
+
+cleanup() {
+  if [ -n "$STAGE_FILE" ]; then
+    rm -f -- "$STAGE_FILE" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+trap 'cleanup; exit 1' HUP INT TERM
+
+is_managed_canonical_target() {
+  canonical_target=$1
+  case "$canonical_target" in
+    ../grok-zh-downloads/*) canonical_name=${canonical_target#../grok-zh-downloads/} ;;
+    *) return 1 ;;
+  esac
+  case "$canonical_name" in
+    ''|.|..|*/*|*\\*|*:*) return 1 ;;
+  esac
+  printf '%s\n' "$canonical_name" | grep -Eq "^grok-zh-${semver_body}-macos-aarch64\\.[0-9A-Za-z-]+\\.installed$"
+}
+
+validate_managed_link() {
+  managed_link=$1
+  managed_kind=$2
+  if [ -L "$managed_link" ]; then
+    managed_target=$(readlink "$managed_link") || die "无法读取符号链接：$managed_link"
+    case "$managed_kind:$managed_target" in
+      agent-entry:grok-zh|grok-alias:grok-zh|agent-alias:agent-zh) return 0 ;;
+    esac
+    if { [ "$managed_kind" = canonical ] || [ "$managed_kind" = agent-entry ]; } && \
+      is_managed_canonical_target "$managed_target"; then
+      return 0
+    fi
+    die "拒绝覆盖不属于本安装器的符号链接：$managed_link -> $managed_target"
+  elif [ -e "$managed_link" ]; then
+    die "拒绝覆盖已有文件：$managed_link"
+  fi
+}
+
+capture_link() {
+  capture_path=$1
+  if [ -L "$capture_path" ]; then
+    readlink "$capture_path"
+  else
+    printf '%s\n' '__ABSENT__'
+  fi
+}
+
+swap_link() {
+  swap_target=$1
+  swap_path=$2
+  LINK_SEQ=$((LINK_SEQ + 1))
+  swap_tmp="${swap_path}.$$.${LINK_SEQ}.tmp-link"
+  [ ! -e "$swap_tmp" ] && [ ! -L "$swap_tmp" ] || return 1
+  ln -s "$swap_target" "$swap_tmp" || return 1
+  if ! mv -f "$swap_tmp" "$swap_path"; then
+    rm -f -- "$swap_tmp" 2>/dev/null || true
+    return 1
+  fi
+}
+
+restore_link() {
+  restore_path=$1
+  restore_target=$2
+  restore_expected=$3
+  if [ ! -L "$restore_path" ] || [ "$(readlink "$restore_path")" != "$restore_expected" ]; then
+    return 0
+  fi
+  if [ "$restore_target" = __ABSENT__ ]; then
+    rm -f -- "$restore_path"
+  else
+    swap_link "$restore_target" "$restore_path"
+  fi
+}
+
+GROK_ZH_LINK="$BIN_DIR/grok-zh"
+AGENT_ZH_LINK="$BIN_DIR/agent-zh"
+GROK_ALIAS_LINK="$BIN_DIR/grok"
+AGENT_ALIAS_LINK="$BIN_DIR/agent"
+validate_managed_link "$GROK_ZH_LINK" canonical
+validate_managed_link "$AGENT_ZH_LINK" agent-entry
+if [ "$WITH_COMPAT_ALIASES" -eq 1 ]; then
+  validate_managed_link "$GROK_ALIAS_LINK" grok-alias
+  validate_managed_link "$AGENT_ALIAS_LINK" agent-alias
+fi
+
+OLD_GROK_ZH=$(capture_link "$GROK_ZH_LINK")
+OLD_AGENT_ZH=$(capture_link "$AGENT_ZH_LINK")
+OLD_GROK_ALIAS=$(capture_link "$GROK_ALIAS_LINK")
+OLD_AGENT_ALIAS=$(capture_link "$AGENT_ALIAS_LINK")
+
+STAGE_FILE=$(mktemp "$DOWNLOAD_DIR/.grok-zh-stage.XXXXXX") || die "无法创建安装暂存文件。"
+cp "$SCRIPT_DIR/grok-zh" "$STAGE_FILE" || die "无法复制 grok-zh。"
+chmod 755 "$STAGE_FILE" || die "无法设置 grok-zh 执行权限。"
+expected_binary_hash=$(awk '$2 == "grok-zh" { print $1 }' "$MANIFEST")
+actual_binary_hash=$(shasum -a 256 "$STAGE_FILE" | awk '{ print $1 }')
+[ "$actual_binary_hash" = "$expected_binary_hash" ] || die "暂存的 grok-zh 校验失败。"
+stage_version_output=$("$STAGE_FILE" --version 2>/dev/null) || die "暂存的 grok-zh 无法运行。"
+stage_version_line=$(printf '%s\n' "$stage_version_output" | sed -n '1p')
+[ "$stage_version_line" = "$version_line" ] || die "暂存的 grok-zh 版本不一致。"
+
+FINAL_RESERVATION=$(mktemp "$DOWNLOAD_DIR/grok-zh-$version-macos-aarch64.XXXXXX") || die "无法预留版本目标。"
+FINAL_FILE="${FINAL_RESERVATION}.installed"
+if ! mv "$FINAL_RESERVATION" "$FINAL_FILE"; then
+  rm -f -- "$FINAL_RESERVATION" 2>/dev/null || true
+  die "无法预留最终版本目标。"
+fi
+if ! mv -f "$STAGE_FILE" "$FINAL_FILE"; then
+  rm -f -- "$FINAL_FILE" 2>/dev/null || true
+  die "无法发布已验证的 grok-zh。"
+fi
+STAGE_FILE=
+FINAL_REL="../grok-zh-downloads/${FINAL_FILE##*/}"
+
+applied_grok_zh=0
+applied_agent_zh=0
+applied_grok_alias=0
+applied_agent_alias=0
+rollback_links() {
+  # If another installer/updater has already advanced the canonical pointer,
+  # none of this process's earlier snapshots may be restored over that winner.
+  if [ "$applied_grok_zh" -eq 1 ] && \
+    { [ ! -L "$GROK_ZH_LINK" ] || [ "$(readlink "$GROK_ZH_LINK")" != "$FINAL_REL" ]; }; then
+    return 0
+  fi
+  rollback_failed=0
+  [ "$applied_agent_alias" -eq 0 ] || restore_link "$AGENT_ALIAS_LINK" "$OLD_AGENT_ALIAS" agent-zh || rollback_failed=1
+  [ "$applied_grok_alias" -eq 0 ] || restore_link "$GROK_ALIAS_LINK" "$OLD_GROK_ALIAS" grok-zh || rollback_failed=1
+  [ "$applied_agent_zh" -eq 0 ] || restore_link "$AGENT_ZH_LINK" "$OLD_AGENT_ZH" grok-zh || rollback_failed=1
+  [ "$applied_grok_zh" -eq 0 ] || restore_link "$GROK_ZH_LINK" "$OLD_GROK_ZH" "$FINAL_REL" || rollback_failed=1
+  [ "$rollback_failed" -eq 0 ]
+}
+
+abort_during_activation() {
+  if ! rollback_links; then
+    printf '%s\n' "${PROGRAM_NAME}: 激活被中断，入口链接未能完全回滚；请检查 $BIN_DIR。" >&2
+  fi
+  cleanup
+  trap - EXIT HUP INT TERM
+  exit 1
+}
+trap abort_during_activation HUP INT TERM
+
+rollback_or_die() {
+  rollback_message=$1
+  if rollback_links; then
+    die "$rollback_message；已回滚入口链接。已验证版本保留在 $FINAL_FILE。"
+  fi
+  die "$rollback_message；入口链接未能完全回滚，请检查 $BIN_DIR。已验证版本保留在 $FINAL_FILE。"
+}
+
+applied_grok_zh=1
+if ! swap_link "$FINAL_REL" "$GROK_ZH_LINK"; then
+  applied_grok_zh=0
+  die "无法激活 grok-zh。已验证版本保留在 $FINAL_FILE。"
+fi
+applied_agent_zh=1
+if ! swap_link grok-zh "$AGENT_ZH_LINK"; then
+  rollback_or_die "无法激活 agent-zh"
+fi
+if [ "$WITH_COMPAT_ALIASES" -eq 1 ]; then
+  applied_grok_alias=1
+  if ! swap_link grok-zh "$GROK_ALIAS_LINK"; then
+    rollback_or_die "无法创建 grok 兼容入口"
+  fi
+  applied_agent_alias=1
+  if ! swap_link agent-zh "$AGENT_ALIAS_LINK"; then
+    rollback_or_die "无法创建 agent 兼容入口"
+  fi
+fi
+
+# All entry points now form one committed link graph. A later signal should
+# only stop output, not undo a successfully activated installation.
+trap 'cleanup; exit 1' HUP INT TERM
+
+printf '\n%s\n' "✓ grok-zh v$version 安装成功。"
+printf '%s\n' "安装目录：$BIN_DIR"
+case ":${CALLER_PATH}:" in
+  *":$BIN_DIR:"*) ;;
+  *)
+    printf '%s\n' '请把下面一行加入 shell 启动文件（例如 ~/.zshrc 或 ~/.bashrc）：'
+    printf 'export PATH='; printf "'%s'" "$(printf '%s' "$BIN_DIR" | sed "s/'/'\\\\''/g")"; printf ':$PATH\n'
+    ;;
+esac
+printf '%s\n' "重新打开终端后运行：grok-zh"
+if [ "$WITH_COMPAT_ALIASES" -eq 1 ]; then
+  printf '%s\n' "兼容入口已启用，也可以运行：grok"
+fi

--- a/packaging/windows/INSTALL-WINDOWS.md
+++ b/packaging/windows/INSTALL-WINDOWS.md
@@ -9,7 +9,7 @@
    下载 `grok-zh-<version>-windows-x86_64-gnu.zip`。开发测试也可从
    **Actions → CI** 下载短期 Artifact。
 2. 解压一次；Release ZIP 内直接是安装包内容。
-3. 确认目录中至少包含：
+3. 确认目录中恰好包含以下受管文件和目录（`SHA256SUMS.txt` 是包内清单，不列入它自身的哈希项）：
 
    ```text
    grok-zh.exe
@@ -19,8 +19,15 @@
    [可选]替换原始启动方式.cmd
    Install-GrokZh.ps1
    INSTALL-WINDOWS.md
-   SHA256SUMS.txt
+   LICENSE-grok-build.txt
    BUILD-INFO.txt
+   licenses/ripgrep/COPYING
+   licenses/ripgrep/LICENSE-MIT
+   licenses/ripgrep/UNLICENSE
+   licenses/project/THIRD-PARTY-NOTICES
+   licenses/project/THIRD_PARTY_NOTICES.md
+   licenses/project/NOTICE
+   SHA256SUMS.txt
    ```
 
 `Install-GrokZh.ps1` 会在写入任何安装目录前，自动核对 `SHA256SUMS.txt` 中的

--- a/packaging/windows/Install-GrokZh.ps1
+++ b/packaging/windows/Install-GrokZh.ps1
@@ -452,6 +452,7 @@ function Read-InteractiveCommandSetup {
 function Read-AndVerifyManifest {
     param([Parameter(Mandatory = $true)][string]$Root)
 
+    Assert-NoReparsePointTree -Path $Root -Label '安装包'
     $manifestPath = Join-Path $Root 'SHA256SUMS.txt'
     if (!(Test-Path -LiteralPath $manifestPath -PathType Leaf)) {
         throw "安装包缺少校验清单：$manifestPath"
@@ -474,7 +475,15 @@ function Read-AndVerifyManifest {
         '一键安装.cmd',
         '[可选]替换原始启动方式.cmd',
         'Install-GrokZh.ps1',
-        'INSTALL-WINDOWS.md'
+        'INSTALL-WINDOWS.md',
+        'LICENSE-grok-build.txt',
+        'BUILD-INFO.txt',
+        'licenses/ripgrep/COPYING',
+        'licenses/ripgrep/LICENSE-MIT',
+        'licenses/ripgrep/UNLICENSE',
+        'licenses/project/THIRD-PARTY-NOTICES',
+        'licenses/project/THIRD_PARTY_NOTICES.md',
+        'licenses/project/NOTICE'
     )
     $allowedUnicodeNames = @('一键安装.cmd', '[可选]替换原始启动方式.cmd')
     foreach ($line in Get-Content -LiteralPath $manifestPath -Encoding UTF8) {
@@ -486,11 +495,14 @@ function Read-AndVerifyManifest {
         }
         $expected = $matches[1].ToUpperInvariant()
         $name = $matches[2]
+        $pathParts = $name.Split('/')
         if ($name.Trim() -ne $name -or
-            $name -ne [IO.Path]::GetFileName($name) -or
+            $name.StartsWith('/') -or
+            $name.Contains('\') -or
             $name.Contains(':') -or
-            $name -in @('.', '..')) {
-            throw "安装包校验清单包含非根目录路径：$name"
+            $pathParts.Count -eq 0 -or
+            @($pathParts | Where-Object { $_ -in @('', '.', '..') }).Count -ne 0) {
+            throw "安装包校验清单包含不安全路径：$name"
         }
         if ($name -ieq 'SHA256SUMS.txt') {
             throw 'SHA256SUMS.txt 不能包含自身哈希条目。'
@@ -825,6 +837,10 @@ try {
     foreach ($name in $installNames) {
         $source = Join-Path $PackageDir $name
         $destination = Join-Path $stage $name
+        $destinationParent = Split-Path -Parent $destination
+        if (!(Test-Path -LiteralPath $destinationParent -PathType Container)) {
+            New-Item -ItemType Directory -Path $destinationParent -Force | Out-Null
+        }
         $length = (Get-Item -LiteralPath $source).Length
         $copiedHash = Copy-PackageFile -Source $source -Destination $destination `
             -DisplayName $name -BytesBefore $copiedBytes -TotalBytes $copyTotalBytes `
@@ -845,22 +861,6 @@ try {
         [string[]]$installedManifestLines,
         (New-Object Text.UTF8Encoding($false))
     )
-    foreach ($name in @('BUILD-INFO.txt', 'LICENSE-grok-build.txt')) {
-        $source = Join-Path $PackageDir $name
-        if (Test-Path -LiteralPath $source -PathType Leaf) {
-            $sourceItem = Get-Item -LiteralPath $source -Force
-            if (($sourceItem.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0) {
-                throw "可选安装包文件不能是符号链接或重解析点：$source"
-            }
-            Copy-Item -LiteralPath $source -Destination (Join-Path $stage $name)
-        }
-    }
-    $licenseSource = Join-Path $PackageDir 'licenses'
-    if (Test-Path -LiteralPath $licenseSource -PathType Container) {
-        Assert-NoReparsePointTree -Path $licenseSource -Label '许可证目录'
-        Copy-Item -LiteralPath $licenseSource -Destination (Join-Path $stage 'licenses') -Recurse
-    }
-
     if ($provideOfficialNames) {
         Write-CommandShim -Path (Join-Path $stage 'grok.cmd') -AgentMode:$false
         Write-CommandShim -Path (Join-Path $stage 'agent.cmd') -AgentMode:$true

--- a/packaging/windows/tests/Test-Install-GrokZh.ps1
+++ b/packaging/windows/tests/Test-Install-GrokZh.ps1
@@ -81,6 +81,21 @@ try {
     Copy-Item -LiteralPath $guide -Destination (Join-Path $package 'INSTALL-WINDOWS.md')
     Set-Content -LiteralPath (Join-Path $package 'BUILD-INFO.txt') `
         -Value "Version: installer-test`nTarget: x86_64-pc-windows-gnu" -Encoding UTF8
+    Set-Content -LiteralPath (Join-Path $package 'LICENSE-grok-build.txt') `
+        -Value 'Apache-2.0 test license' -Encoding UTF8
+    $licenseFiles = [ordered]@{
+        'licenses/ripgrep/COPYING' = 'ripgrep COPYING'
+        'licenses/ripgrep/LICENSE-MIT' = 'ripgrep MIT'
+        'licenses/ripgrep/UNLICENSE' = 'ripgrep UNLICENSE'
+        'licenses/project/THIRD-PARTY-NOTICES' = 'project third-party notices'
+        'licenses/project/THIRD_PARTY_NOTICES.md' = 'project tool notices'
+        'licenses/project/NOTICE' = 'project NOTICE'
+    }
+    foreach ($entry in $licenseFiles.GetEnumerator()) {
+        $path = Join-Path $package $entry.Key
+        New-Item -ItemType Directory -Path (Split-Path -Parent $path) -Force | Out-Null
+        Set-Content -LiteralPath $path -Value $entry.Value -Encoding UTF8
+    }
 
     $names = @(
         'grok-zh.exe',
@@ -89,7 +104,15 @@ try {
         '一键安装.cmd',
         '[可选]替换原始启动方式.cmd',
         'Install-GrokZh.ps1',
-        'INSTALL-WINDOWS.md'
+        'INSTALL-WINDOWS.md',
+        'LICENSE-grok-build.txt',
+        'BUILD-INFO.txt',
+        'licenses/ripgrep/COPYING',
+        'licenses/ripgrep/LICENSE-MIT',
+        'licenses/ripgrep/UNLICENSE',
+        'licenses/project/THIRD-PARTY-NOTICES',
+        'licenses/project/THIRD_PARTY_NOTICES.md',
+        'licenses/project/NOTICE'
     )
     $lines = foreach ($name in $names) {
         $hash = (Get-FileHash -LiteralPath (Join-Path $package $name) -Algorithm SHA256).Hash
@@ -126,6 +149,11 @@ try {
     Assert-True (Test-Path -LiteralPath (Join-Path $defaultInstall 'grok-zh.exe')) '未安装 grok-zh.exe'
     Assert-True (Test-Path -LiteralPath (Join-Path $defaultInstall 'agent-zh.cmd')) '未安装 agent-zh.cmd'
     Assert-True (Test-Path -LiteralPath (Join-Path $defaultInstall 'rg.exe')) '未在 grok-zh.exe 同目录安装 rg.exe'
+    Assert-True (Test-Path -LiteralPath (Join-Path $defaultInstall 'BUILD-INFO.txt')) '未安装受校验的构建信息'
+    Assert-True (Test-Path -LiteralPath (Join-Path $defaultInstall 'LICENSE-grok-build.txt')) '未安装受校验的主许可证'
+    foreach ($relativeLicense in $licenseFiles.Keys) {
+        Assert-True (Test-Path -LiteralPath (Join-Path $defaultInstall $relativeLicense) -PathType Leaf) "未安装受校验的许可证文件：$relativeLicense"
+    }
     Assert-True (!(Test-Path -LiteralPath (Join-Path $defaultInstall '一键安装.cmd'))) '一键入口只应保留在解压包根，不应复制到安装目录'
     Assert-True (!(Test-Path -LiteralPath (Join-Path $defaultInstall '[可选]替换原始启动方式.cmd'))) '可选入口只应保留在解压包根，不应复制到安装目录'
     Assert-True (!(Test-Path -LiteralPath (Join-Path $defaultInstall 'Install-GrokZh.ps1'))) '安装脚本只应保留在解压包根，不应复制到运行目录'


### PR DESCRIPTION
## 说明

本 PR 建立在已经正常合并的 #2 和后续加固 #3 之上，不替代、不复制贡献者提交；`dddwill8` 的 macOS ARM 工作流提交继续保留在 `zh-dev` 历史中。

## 主要变更

- 社区版更新器只消费 `JoyElliot/grok-build-Chinese` 的 Immutable Releases，并严格校验资产状态、大小、GitHub digest、旁车 SHA-256、包内清单和候选程序版本。
- Windows ZIP 与 macOS ARM64 tar.gz 使用精确文件集合；macOS 额外拒绝危险路径、链接、错误模式、截断 USTAR、拼接 gzip 和尾随数据。
- 新增 macOS ARM64 安装器：版本化不可变目标、原子链接切换、失败回滚、`grok-zh` / `agent-zh`，以及显式启用的 `grok` / `agent` 兼容别名。
- 社区 macOS/Windows 均支持本仓库权威 Release 指针的升级与有意回退；更新下载到 100% 后保留完成状态。
- 正式发布工作流统一汇总 Windows/macOS 资产、attestation、Draft 身份/哈希复核、按数字 Release ID 发布及失败 Draft 清理。
- `v1.0.6` 保持 Windows 两项资产契约；从 `v1.0.7`（含预发布）起要求 Windows/macOS 四项资产。
- Windows 预览包、正式包、安装器、更新器和文档统一为完整 15 文件清单（另含包内 `SHA256SUMS.txt`）。

## 本地验证

- `actionlint`：三份相关工作流通过
- `sh -n packaging/macos/Install-GrokZh.sh`：通过
- Windows PowerShell 5.1 安装器测试：通过
- `cargo fmt --all -- --check`：通过
- `cargo metadata --locked --no-deps`：通过
- `git diff --check`：通过
- 两轮独立静态终审：未发现剩余合并阻断

真实 Windows 构建、Rust 完整测试与 Apple Silicon 安装/链接 smoke 由本 PR 的 GitHub Actions 验证。本 PR 不创建 Tag，也不发布 Release。